### PR TITLE
Fix empty registration link

### DIFF
--- a/src/N2.Templates.Mvc/Views/Login/Index.ascx
+++ b/src/N2.Templates.Mvc/Views/Login/Index.ascx
@@ -23,7 +23,9 @@
 				<%=Html.AntiForgeryToken("login")%>
 				<input value="Login" type="submit" />
 				<%=Html.ValidationMessage("Login.Failed")%>
+                <% if (CurrentItem.RegisterPage != null) { %>
 				<%= Html.ActionLink(CurrentItem.RegisterPage) %>
+                <% } %>
 			</div>
 			<%}%>
 			<%}%>


### PR DESCRIPTION
Sometimes it is useful to NOT allow users to register. This patch fixes the 'crash' when the registration page link is set empty, as well as does NOT display a 'Register' link in that case.
