### PR TITLE
Fix build batch

### DIFF
--- a/Prepare_AllDependencies.bat
+++ b/Prepare_AllDependencies.bat
@@ -1,3 +1,3 @@
 @echo off
 cd /d %~dp0build
-cmd /c "build.bat /target:PrepareDependencies" & pause & exit 
+cmd /c "build.bat /target:PrepareDependencies" & pause & exit /b


### PR DESCRIPTION
First, do not close cmd.exe when invoking the batch, apart from double clicking it. Also, use an absolute path for the build files, so a "Run as Administrator" won't fail because of the folder switching involved.
