### PR TITLE
Fixed: DisplayableTokensAttibute Error

### DIFF
--- a/src/Framework/N2/Details/DisplayableTokensAttribute.cs
+++ b/src/Framework/N2/Details/DisplayableTokensAttribute.cs
@@ -72,9 +72,9 @@ namespace N2.Details
 					else
 						dc.Details.Add(cd);
 					i++;
-                }
-                // Changed: if (i > 0) --> if (i >= 0)
-                // If i == 0, no Tokens were found, so remove all details.
+                                }
+                                // Changed: if (i > 0) --> if (i >= 0)
+                                // If i == 0, no Tokens were found, so remove all details.
 				if (i >= 0)
 				{
 					var dc = item.GetDetailCollection(detailName, true);


### PR DESCRIPTION
Deleting all Tokens from an Editable caused an error that keeps that Editable from being rendered (especially when SwallowExceptions() is being called). When no Tokens were found, the previously existing Tokens were not being removed from the Details.
