### PR TITLE
Do not modify AlteredPermissions when they are not set. This hopefully p...

### DIFF
--- a/src/Framework/N2/Persistence/NH/NHInterceptor.cs
+++ b/src/Framework/N2/Persistence/NH/NHInterceptor.cs
@@ -110,13 +110,6 @@ namespace N2.Persistence.NH
 						wasAltered = true;
 					}
 				}
-				if (propertyNames[i] == "AlteredPermissions" 
-					&& item.AlteredPermissions == N2.Security.Permission.None 
-					&& item.AuthorizedRoles.Count > 0)
-				{
-					state[i] = N2.Security.Permission.Read;
-					wasAltered = true;
-				}
 			}
 			return wasAltered;
 		}


### PR DESCRIPTION
...revents N2 from saving items that were fetched but not modified. Especially in the case of lazy loaded collections (like Children), this should improve performance, because N2 tends to implicitly load these nodes. All these implicitly loaded collections would be saved on a closing transaction because the AlteredPermissions were suddenly set.

I'm not sure why the line existed in the first place, but it might have solved a case that's not applicable anymore. Unit tests are green anyway.
