### PR TITLE
(value is DateTime?) == false when value == null

### DIFF
--- a/src/Framework/N2/Details/EditableDateAttribute.cs
+++ b/src/Framework/N2/Details/EditableDateAttribute.cs
@@ -61,7 +61,9 @@ namespace N2.Details
 		{
 			DatePicker picker = (DatePicker) editor;
             object value = item[Name];
-            if (value is DateTime?)
+            if (value == null)
+                picker.SelectedDate = null;
+            else if (value is DateTime?)
                 picker.SelectedDate = (DateTime?)value;
             else if (value is DateTime)
                 picker.SelectedDate = (DateTime?)value;


### PR DESCRIPTION
which causes the Convert to throw a NullReference
