### PR TITLE
Wrong content being returned for urls with no content

### DIFF
--- a/src/Framework/N2/Web/NonRewritableAttribute.cs
+++ b/src/Framework/N2/Web/NonRewritableAttribute.cs
@@ -13,7 +13,8 @@ namespace N2.Web
 	{
 		public PathData GetPath(ContentItem item, string remainingUrl)
 		{
-			return new PathData(item) { IsRewritable = false };
+			if (item.Name == remainingUrl || string.IsNullOrEmpty(remainingUrl))
+				return new PathData(item) { IsRewritable = false };
 		}
 	}
 }


### PR DESCRIPTION
Fix issue where wrong content was being returned for urls with no content when using Engine.UrlParser.CurrentPage.
