### PR TITLE
adding support for controller namespaces for content routes

### DIFF
--- a/src/Framework/Extensions/Web/Mvc/AreaRegistrationExtensions.cs
+++ b/src/Framework/Extensions/Web/Mvc/AreaRegistrationExtensions.cs
@@ -25,7 +25,7 @@ namespace N2.Web.Mvc
 		/// <param name="name">The name of this route.</param>
 		/// <param name="engine">The N2 Engine instance used by the content route.</param>
 		/// <returns>The added content route instance.</returns>
-		public static ContentRoute MapContentRoute<T>(this AreaRegistrationContext arc)
+		public static ContentRoute MapContentRoute<T>(this AreaRegistrationContext arc, string[] namespaces = null)
 			where T: ContentItem
 		{
 			var state = arc.State as AreaRegistrationState;
@@ -37,7 +37,7 @@ namespace N2.Web.Mvc
 			var innerRoute = new Route("{area}/{controller}/{action}",
 				new RouteValueDictionary(new { action = "Index" }),
 				new RouteValueDictionary(),
-				new RouteValueDictionary(new { engine = state.Engine, area = arc.AreaName }),
+				new RouteValueDictionary(new { engine = state.Engine, area = arc.AreaName, namespaces }),
 				routeHandler);
 
 			var cr = new ContentRoute<T>(state.Engine, routeHandler, controllerMapper, innerRoute);

--- a/src/Framework/N2/Web/Mvc/ContentRoute.cs
+++ b/src/Framework/N2/Web/Mvc/ContentRoute.cs
@@ -52,7 +52,7 @@ namespace N2.Web.Mvc
 		{
 		}
 
-		public ContentRoute(IEngine engine, IRouteHandler routeHandler, IControllerMapper controllerMapper, Route innerRoute)
+		public ContentRoute(IEngine engine, IRouteHandler routeHandler, IControllerMapper controllerMapper, Route innerRoute, string[] namespaces = null)
 		{
 			managementPath = Url.ToRelative(Url.ResolveTokens(Url.ManagementUrlToken + "/"));
 			this.engine = engine;
@@ -60,8 +60,8 @@ namespace N2.Web.Mvc
 			this.controllerMapper = controllerMapper ?? engine.Resolve<IControllerMapper>();
 			this.innerRoute = innerRoute ?? new Route("{controller}/{action}", 
 				new RouteValueDictionary(new { action = "Index" }), 
-				new RouteValueDictionary(), 
-				new RouteValueDictionary(new { this.engine }), 
+				new RouteValueDictionary(),
+				new RouteValueDictionary(new { this.engine, namespaces }), 
 				this.routeHandler);
 		}
 

--- a/src/Framework/N2/Web/Mvc/RouteCollectionExtensions.cs
+++ b/src/Framework/N2/Web/Mvc/RouteCollectionExtensions.cs
@@ -16,12 +16,13 @@ namespace N2.Web.Mvc
 		/// <param name="routes">The route collection to extend.</param>
 		/// <param name="name">The name of this route.</param>
 		/// <param name="engine">The N2 Engine instance used by the content route.</param>
-        /// <param name="append">Append is useful in scenarios where you want to override the routing of specific urls also considered by N2.</param>
+		/// <param name="append">Append is useful in scenarios where you want to override the routing of specific urls also considered by N2.</param>
 		/// <param name="stopRewritableItems">Make the route table stop at items that match an item that can be rewritten to (probably webforms).</param>
-        /// <returns>The added content route instance.</returns>
-		public static ContentRoute MapContentRoute(this RouteCollection routes, string name, IEngine engine, bool append = false, bool stopRewritableItems = true)
+		/// <param name="namespaces">The namespaces the routing engine will look for the controller in</param>
+		/// <returns>The added content route instance.</returns>
+		public static ContentRoute MapContentRoute(this RouteCollection routes, string name, IEngine engine, bool append = false, bool stopRewritableItems = true, string[] namespaces = null)
 		{
-			var cr = new ContentRoute(engine) { StopRewritableItems = stopRewritableItems };
+			var cr = new ContentRoute(engine, null, null, null, namespaces) { StopRewritableItems = stopRewritableItems };
             if (append)
             {
                 routes.Add(cr);


### PR DESCRIPTION
this change allows to use mvc's built in feature that restricts
controller lookups to certain namespaces
