### PR TITLE
allow to specify cache region name for NH's 2nd level cache

### DIFF
--- a/docs/n2cms.configuration.xsd
+++ b/docs/n2cms.configuration.xsd
@@ -373,6 +373,7 @@
 						<xs:attribute name="caching" type="xs:boolean" use="optional" />
 						<xs:attribute name="tryLocatingHbmResources" type="xs:boolean" use="optional" />
 						<xs:attribute name="cacheProviderClass" type="xs:string" use="optional" />
+						<xs:attribute name="cacheRegion" type="xs:string" use="optional" />
 						<xs:attribute name="connectionStringName" type="xs:string" use="optional" />
 						<xs:attribute name="flavour" use="optional">
 							<xs:simpleType>

--- a/src/Framework/N2/Configuration/DatabaseSection.cs
+++ b/src/Framework/N2/Configuration/DatabaseSection.cs
@@ -39,6 +39,14 @@ namespace N2.Configuration
 			set { base["cacheProviderClass"] = value; }
 		}
 
+		/// <summary>The cache region name to use.</summary>
+		[ConfigurationProperty("cacheRegion", DefaultValue = "N2CMS")]
+		public string CacheRegion
+		{
+			get { return (string)base["cacheRegion"]; }
+			set { base["cacheRegion"] = value; }
+		}
+
 		/// <summary>The name of the sql dependency to use for cache invalidation.</summary>
 		/// <remarks>This setting must be enabled in SQL Server using aspnet_regsql.exe.</remarks>
 		[ConfigurationProperty("sqlCacheDependency")]

--- a/src/Framework/N2/Persistence/NH/ConfigurationBuilder.cs
+++ b/src/Framework/N2/Persistence/NH/ConfigurationBuilder.cs
@@ -46,7 +46,8 @@ namespace N2.Persistence.NH
 		Cascade childrenCascade = Cascade.None;
 		int stringLength = 1073741823;
 		bool tryLocatingHbmResources = false;
-		
+		private string cacheRegion;
+
 		/// <summary>Creates a new instance of the <see cref="ConfigurationBuilder"/>.</summary>
 		public ConfigurationBuilder(IDefinitionProvider[] definitionProviders, ClassMappingGenerator generator, IWebContext webContext, ConfigurationBuilderParticipator[] participators, DatabaseSection config, ConnectionStringsSection connectionStrings)
 		{
@@ -61,6 +62,7 @@ namespace N2.Persistence.NH
 			batchSize = config.BatchSize;
 			childrenLaziness = config.Children.Laziness;
 			childrenCascade = config.Children.Cascade;
+			cacheRegion = config.CacheRegion;
 
 			SetupProperties(config, connectionStrings);
 			SetupMappings(config);
@@ -283,7 +285,7 @@ namespace N2.Persistence.NH
 		{
 			ca.Table(tablePrefix + "Item");
 			ca.Lazy(false);
-			ca.Cache(cm => { cm.Usage(CacheUsage.NonstrictReadWrite); });
+			ca.Cache(cm => { cm.Usage(CacheUsage.NonstrictReadWrite); cm.Region(cacheRegion); });
 			ca.Id(x => x.ID, cm => { cm.Generator(Generators.Native); });
 			ca.Discriminator(cm => { cm.Column("Type"); cm.Type(NHibernateUtil.String); });
 			ca.Property(x => x.Created, cm => { });
@@ -323,7 +325,7 @@ namespace N2.Persistence.NH
 				cm.OrderBy(ci => ci.SortOrder);
 				cm.Lazy(childrenLaziness);
 				cm.BatchSize(batchSize ?? 25);
-				cm.Cache(m => m.Usage(CacheUsage.NonstrictReadWrite));
+				cm.Cache(m => { m.Usage(CacheUsage.NonstrictReadWrite); m.Region(cacheRegion); });
 			}, cr => cr.OneToMany());
 			ca.Bag(x => x.Details, cm =>
 			{
@@ -333,7 +335,7 @@ namespace N2.Persistence.NH
 				cm.Cascade(Cascade.All | Cascade.DeleteOrphans);
 				cm.Fetch(CollectionFetchMode.Select);
 				cm.Lazy(CollectionLazy.Lazy);
-				cm.Cache(m => m.Usage(CacheUsage.NonstrictReadWrite));
+				cm.Cache(m => { m.Usage(CacheUsage.NonstrictReadWrite); m.Region(cacheRegion); });
 				cm.Where("DetailCollectionID IS NULL");
 			}, cr => cr.OneToMany());
 			ca.Bag(x => x.DetailCollections, cm =>
@@ -344,7 +346,7 @@ namespace N2.Persistence.NH
 				cm.Cascade(Cascade.All | Cascade.DeleteOrphans);
 				cm.Fetch(CollectionFetchMode.Select);
 				cm.Lazy(CollectionLazy.Lazy);
-				cm.Cache(m => m.Usage(CacheUsage.NonstrictReadWrite));
+				cm.Cache(m => { m.Usage(CacheUsage.NonstrictReadWrite); m.Region(cacheRegion); });
 			}, cr => cr.OneToMany());
 			ca.Bag(x => x.AuthorizedRoles, cm =>
 			{
@@ -353,7 +355,7 @@ namespace N2.Persistence.NH
 				cm.Cascade(Cascade.All | Cascade.DeleteOrphans);
 				cm.Fetch(CollectionFetchMode.Select);
 				cm.Lazy(CollectionLazy.Lazy);
-				cm.Cache(m => m.Usage(CacheUsage.NonstrictReadWrite));
+				cm.Cache(m => { m.Usage(CacheUsage.NonstrictReadWrite); m.Region(cacheRegion); });
 			}, cr => cr.OneToMany());
 		}
 
@@ -361,7 +363,7 @@ namespace N2.Persistence.NH
 		{
 			ca.Table(tablePrefix + "Detail");
 			ca.Lazy(true);
-			ca.Cache(cm => { cm.Usage(CacheUsage.NonstrictReadWrite); });
+			ca.Cache(cm => { cm.Usage(CacheUsage.NonstrictReadWrite); cm.Region(cacheRegion); });
 			ca.Id(x => x.ID, cm => { cm.Generator(Generators.Native); });
 			ca.ManyToOne(x => x.EnclosingItem, cm => { cm.Column("ItemID"); cm.NotNullable(true); cm.Fetch(FetchKind.Select); cm.Lazy(LazyRelation.Proxy); });
 			ca.ManyToOne(x => x.EnclosingCollection, cm => { cm.Column("DetailCollectionID"); cm.Fetch(FetchKind.Select); cm.Lazy(LazyRelation.Proxy); });
@@ -385,7 +387,7 @@ namespace N2.Persistence.NH
 		{
 			ca.Table(tablePrefix + "DetailCollection");
 			ca.Lazy(true);
-			ca.Cache(cm => { cm.Usage(CacheUsage.NonstrictReadWrite); });
+			ca.Cache(cm => { cm.Usage(CacheUsage.NonstrictReadWrite); cm.Region(cacheRegion); });
 			ca.Id(x => x.ID, cm => { cm.Generator(Generators.Native); });
 			ca.ManyToOne(x => x.EnclosingItem, cm => { cm.Column("ItemID"); cm.Fetch(FetchKind.Select); cm.Lazy(LazyRelation.Proxy); });
 			ca.Property(x => x.Name, cm => { cm.Length(50); cm.NotNullable(true); });
@@ -396,7 +398,7 @@ namespace N2.Persistence.NH
 				cm.Cascade(Cascade.All | Cascade.DeleteOrphans);
 				cm.Lazy(CollectionLazy.Lazy);
 				cm.Fetch(CollectionFetchMode.Select);
-				cm.Cache(m => m.Usage(CacheUsage.NonstrictReadWrite));
+				cm.Cache(m => { m.Usage(CacheUsage.NonstrictReadWrite); m.Region(cacheRegion); });
 			}, cr => cr.OneToMany());
 		}
 
@@ -404,7 +406,7 @@ namespace N2.Persistence.NH
 		{
 			ca.Table(tablePrefix + "AllowedRole");
 			ca.Lazy(false);
-			ca.Cache(cm => { cm.Usage(CacheUsage.NonstrictReadWrite); });
+			ca.Cache(cm => { cm.Usage(CacheUsage.NonstrictReadWrite); cm.Region(cacheRegion); });
 			ca.Id(x => x.ID, cm => { cm.Generator(Generators.Native); });
 			ca.ManyToOne(x => x.EnclosingItem, cm => { cm.Column("ItemID"); cm.NotNullable(true); });
 			ca.Property(x => x.Role, cm => { cm.Length(50); cm.NotNullable(true); });


### PR DESCRIPTION
adding database configuration property to specify cache region name to
use, and modified default mappings to use that cache region name
