### PR TITLE
missing content type in VPP handler

### DIFF
--- a/src/Framework/Packaging/Web/Hosting/VirtualPathFileHandler.cs
+++ b/src/Framework/Packaging/Web/Hosting/VirtualPathFileHandler.cs
@@ -41,6 +41,7 @@ namespace N2.Web.Hosting
 
 				logger.DebugFormat("Transmitting virtual file {0} available on disk {1}", context.Request.AppRelativeCurrentExecutionFilePath, context.Request.PhysicalPath);
 				N2.Web.CacheUtility.SetValidUntilExpires(context.Response, DateTime.UtcNow);
+				context.Response.ContentType = GetContentType(context.Request.PhysicalPath);
 				context.Response.TransmitFile(context.Request.PhysicalPath);
 			}
 			else if (vpp.FileExists(context.Request.AppRelativeCurrentExecutionFilePath))


### PR DESCRIPTION
The VirtualPathProvider responsible for the /N2/N2.Zip was not setting the content type (mime type) for physically existing files.
