### PR TITLE
open files for read-only access

### DIFF
--- a/src/Framework/N2/Edit/FileSystem/IFileSystem.cs
+++ b/src/Framework/N2/Edit/FileSystem/IFileSystem.cs
@@ -50,8 +50,9 @@ namespace N2.Edit.FileSystem
 
 		/// <summary>Opens a read-write file stream to a file.</summary>
 		/// <param name="virtualPath">The path where the file is located.</param>
+		/// <param name="readOnly">Return a read-only stream if the underlying implementation supports it.</param>
 		/// <returns>A file stream.</returns>
-		Stream OpenFile(string virtualPath); // option 1: work against a file stream
+		Stream OpenFile(string virtualPath, bool readOnly = false); // option 1: work against a file stream
 
 		/// <summary>Creates or overwrites a file at the given path.</summary>
 		/// <param name="virtualPath">The path of the file to create.</param>

--- a/src/Framework/N2/Edit/FileSystem/MappedFileSystem.cs
+++ b/src/Framework/N2/Edit/FileSystem/MappedFileSystem.cs
@@ -120,9 +120,12 @@ namespace N2.Edit.FileSystem
 			File.Copy(MapPath(fromVirtualPath), MapPath(destinationVirtualPath));
 		}
 
-		public System.IO.Stream OpenFile(string virtualPath)
+		public System.IO.Stream OpenFile(string virtualPath, bool readOnly = false)
 		{
-			return File.Open(MapPath(virtualPath), FileMode.OpenOrCreate);
+			FileAccess access = readOnly ? FileAccess.Read : FileAccess.ReadWrite;
+			FileShare share = readOnly ? FileShare.Read : FileShare.None;
+
+			return File.Open(MapPath(virtualPath), FileMode.OpenOrCreate, access, share);
 		}
 
 		public void WriteFile(string virtualPath, System.IO.Stream inputStream)

--- a/src/Framework/N2/Edit/FileSystem/NH/DatabaseFileSystem.cs
+++ b/src/Framework/N2/Edit/FileSystem/NH/DatabaseFileSystem.cs
@@ -200,7 +200,7 @@ namespace N2.Edit.FileSystem.NH
 			get { return _sessionProvider.OpenSession.Session; }
 		}
 
-        public Stream OpenFile(string virtualPath)
+		public Stream OpenFile(string virtualPath, bool readOnly = false)
         {
             var path = FileSystemPath.File(virtualPath);
 

--- a/src/Framework/N2/Edit/FileSystem/VirtualPathFileSystem.cs
+++ b/src/Framework/N2/Edit/FileSystem/VirtualPathFileSystem.cs
@@ -181,14 +181,18 @@ namespace N2.Edit.FileSystem
 				DirectoryCreated.Invoke(this, new FileEventArgs(virtualPath, null));
 		}
 
-		public virtual Stream OpenFile(string virtualPath)
+		public virtual Stream OpenFile(string virtualPath, bool readOnly = false)
 		{
 			if(FileExists(virtualPath))
 			{
 				VirtualFile file = PathProvider.GetFile(virtualPath);
 				return file.Open();
 			}
-			return File.Open(MapPath(virtualPath), FileMode.OpenOrCreate);
+
+			FileAccess access = readOnly ? FileAccess.Read : FileAccess.ReadWrite;
+			FileShare share = readOnly ? FileShare.Read : FileShare.None;
+
+			return File.Open(MapPath(virtualPath), FileMode.OpenOrCreate, access, share);
 		}
 
 		/// <summary>Creates or overwrites a file at the given path.</summary>

--- a/src/Framework/N2/Persistence/Serialization/FileAttachmentAttribute.cs
+++ b/src/Framework/N2/Persistence/Serialization/FileAttachmentAttribute.cs
@@ -25,7 +25,7 @@ namespace N2.Persistence.Serialization
 					{
 						ew.WriteAttribute("url", url);
 
-						using (var s = fs.OpenFile(path))
+						using (var s = fs.OpenFile(path, readOnly: true))
 						{
 							byte[] fileContents = ReadFully(s);
 							string base64representation = Convert.ToBase64String(fileContents);

--- a/src/Framework/N2/Web/Drawing/ImageResizeHandler.cs
+++ b/src/Framework/N2/Web/Drawing/ImageResizeHandler.cs
@@ -52,7 +52,7 @@ namespace N2.Web.Drawing
 				ImageResizer ir = N2.Context.Current.Resolve<ImageResizer>();
 
 				CacheUtility.SetValidUntilExpires(context.Response, TimeSpan.FromDays(7));
-				using (var s = fs.OpenFile(imageUrl))
+				using (var s = fs.OpenFile(imageUrl, readOnly: true))
 				{
 					var resized = ir.GetResizedBytes(s, new ImageResizeParameters(width, height, mode));
 					context.Response.BinaryWrite(resized);

--- a/src/Framework/Tests/Fakes/FakeMemoryFileSystem.cs
+++ b/src/Framework/Tests/Fakes/FakeMemoryFileSystem.cs
@@ -53,7 +53,7 @@ namespace N2.Tests.Fakes
 			files[destinationVirtualPath] = files[fromVirtualPath];
 		}
 
-		public System.IO.Stream OpenFile(string virtualPath)
+		public System.IO.Stream OpenFile(string virtualPath, bool readOnly = false)
 		{
 			return new MemoryStream(contents[virtualPath]);
 		}


### PR DESCRIPTION
allows to specify if you want to open a file with read-only access thus
resolving exclusive file access issues when dynamically resizing images
with image resizer and exporting file attachments that a referenced by
multiple content items
