### PR TITLE
Wrong content being returned if using NonRewritableAttribute

### DIFF
--- a/src/Framework/N2/Web/NonRewritableAttribute.cs
+++ b/src/Framework/N2/Web/NonRewritableAttribute.cs
@@ -13,7 +13,10 @@ namespace N2.Web
 	{
 		public PathData GetPath(ContentItem item, string remainingUrl)
 		{
-			return new PathData(item) { IsRewritable = false };
+			if (string.IsNullOrEmpty(remainingUrl))
+				return new PathData(item) { IsRewritable = false };
+				
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
When you browse to a page which doesn't have any content but has a ancestor with content, then N2 was wrongly returning the ancestor's ContentItem for the page with no content.

This fixes the issue.
