### PR TITLE
Remove DateTime.Now dependency from ContentItem ctor

### DIFF
--- a/src/Framework/N2/ContentItem.cs
+++ b/src/Framework/N2/ContentItem.cs
@@ -115,11 +115,12 @@ namespace N2
 
         #region Constructor
         /// <summary>Creates a new instance of the ContentItem.</summary>
-		public ContentItem()
+		protected ContentItem()
         {
-            created = DateTime.Now;
-            updated = DateTime.Now;
-            published = DateTime.Now;
+            var currentTime = Utility.CurrentTime();
+            created = currentTime;
+            updated = currentTime;
+            published = currentTime;
         }
         #endregion
 


### PR DESCRIPTION
Changed the ContentItem ctor to use Utility.CurrentTime() instead of DateTime.Now to enable mocking of the date.
