### PR TITLE
Reimplementation of slug generation

### DIFF
--- a/src/Framework/N2/Configuration/PatternValueCollection.cs
+++ b/src/Framework/N2/Configuration/PatternValueCollection.cs
@@ -10,24 +10,13 @@ namespace N2.Configuration
 	{
 		public PatternValueCollection()
 		{
-			AddDefault(new PatternValueElement("smallA", "[åáàâã@]", "a", true));
-			AddDefault(new PatternValueElement("capitalA", "[ÅÁÀÂÃ]", "a", true));
+			AddDefault(new PatternValueElement("At", "[@]", "a", true));
 			AddDefault(new PatternValueElement("smallAE", "[æä]", "ae", true));
 			AddDefault(new PatternValueElement("capitalAE", "[ÆÄ]", "Ae", true));
-			AddDefault(new PatternValueElement("smallE", "[éè]", "e", true));
-			AddDefault(new PatternValueElement("capitalE", "[ÉÈ]", "E", true));
-			AddDefault(new PatternValueElement("smallI", "[íì]", "i", true));
-			AddDefault(new PatternValueElement("capitalI", "[ÍÌ]", "I", true));
-			AddDefault(new PatternValueElement("smallO", "[øóòôõ]", "o", true));
-			AddDefault(new PatternValueElement("capitalO", "[ØÓÒÔÕ]", "O", true));
 			AddDefault(new PatternValueElement("smallOE", "[ö]", "oe", true));
 			AddDefault(new PatternValueElement("capitalOE", "[Ö]", "Oe", true));
-			AddDefault(new PatternValueElement("smallU", "[úù]", "u", true));
-			AddDefault(new PatternValueElement("capitalU", "[ÚÙ]", "U", true));
 			AddDefault(new PatternValueElement("smallUE", "[ü]", "ue", true));
 			AddDefault(new PatternValueElement("capitalUE", "[Ü]", "Ue", true));
-			AddDefault(new PatternValueElement("germanSZ", "[ß]", "ss", true));
-			AddDefault(new PatternValueElement("theRest", "[^. a-zA-Z0-9_-]", "", true));
 		}
 	}
 }

--- a/src/Framework/N2/Edit/SlugGenerator.cs
+++ b/src/Framework/N2/Edit/SlugGenerator.cs
@@ -1,0 +1,40 @@
+﻿using System.Web;
+using N2.Engine;
+using N2.Web;
+
+namespace N2.Edit
+{
+	[Service(typeof(IAjaxService))]
+	public class SlugGenerator : IAjaxService
+	{
+		private Slug slug;
+
+		public SlugGenerator(Slug slug)
+		{
+			this.slug = slug;
+		}
+
+		public string Name
+		{
+			get { return "sluggenerator"; }
+		}
+
+		public bool RequiresEditAccess
+		{
+			get { return false; }
+		}
+
+		public bool IsValidHttpMethod(string httpMethod)
+		{
+			return true;
+		}
+
+		public void Handle(HttpContextBase context)
+		{
+			string text = context.Request["title"];
+
+			context.Response.ContentType = "text/plain";
+			context.Response.Write(this.slug.Create(text));
+		}
+	}
+}

--- a/src/Framework/N2/N2.csproj
+++ b/src/Framework/N2/N2.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Edit\MetaInfo.cs" />
     <Compile Include="Definitions\GroupChildrenAttribute.cs" />
     <Compile Include="Definitions\GroupChildrenMode.cs" />
+    <Compile Include="Edit\SlugGenerator.cs" />
     <Compile Include="Edit\Versioning\ContentVersionCleanup.cs" />
     <Compile Include="Edit\Versioning\VersioningExtensions.cs" />
     <Compile Include="Edit\Versioning\DraftRepository.cs" />
@@ -703,6 +704,7 @@
     <Compile Include="Web\Rendering\DisplayableTokenRenderer.cs" />
     <Compile Include="Web\Rendering\IContentRenderer.cs" />
     <Compile Include="Web\Rendering\RenderingExtensions.cs" />
+    <Compile Include="Web\Slug.cs" />
     <Compile Include="Web\TagWrapper.cs" />
     <Compile Include="Web\Rendering\DisplayableToken.cs" />
     <Compile Include="Web\Tokens\TokenDefinition.cs" />

--- a/src/Framework/N2/Web/Slug.cs
+++ b/src/Framework/N2/Web/Slug.cs
@@ -1,0 +1,267 @@
+﻿namespace N2.Web
+{
+	using System;
+	using System.Text;
+	using System.Text.RegularExpressions;
+	using Configuration;
+	using Engine;
+
+	/// <summary>
+	/// Slug (web publishing) : a user- and SEO-friendly short text used in a URL to identify and describe a resource
+	/// </summary>
+	[Service]
+	public class Slug
+	{
+		/// <summary>
+		/// Patterns for replacing single characters
+		/// </summary>
+		private readonly PatternValueCollection replacementPatterns = new PatternValueCollection();
+
+		/// <summary>
+		/// Character that will replace whitespaces
+		/// </summary>
+		private readonly char whitespaceReplacement = '-';
+
+		/// <summary>
+		/// The to lower.
+		/// </summary>
+		private readonly bool toLower = true;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Slug"/> class.
+		/// </summary>
+		/// <param name="configuration">
+		/// Configuration from web.config
+		/// </param>
+		/// <exception cref="ArgumentNullException">
+		/// If configuration is null
+		/// </exception>
+		public Slug(ConfigurationManagerWrapper configuration)
+		{
+			if (configuration == null)
+			{
+				throw new ArgumentNullException("configuration");
+			}
+
+			NameEditorElement nameEditorElement = configuration.Sections.Management.NameEditor;
+
+			// start with empty collection
+			this.replacementPatterns.Clear();
+
+			// first add any replacements from custom configuration, which will be applied first
+			foreach (PatternValueElement element in nameEditorElement.Replacements.AllElements)
+			{
+				this.replacementPatterns.Add(element);
+			}
+
+			// then, add system replacements inserted from constructor
+			foreach (PatternValueElement element in new PatternValueCollection())
+			{
+				this.replacementPatterns.Add(element);
+			}
+
+			this.whitespaceReplacement = nameEditorElement.WhitespaceReplacement;
+			this.toLower = nameEditorElement.ToLower;
+		}
+
+		/// <summary>
+		/// Creates slug from <see cref="text"/>
+		/// </summary>
+		/// <param name="text">
+		/// The text.
+		/// </param>
+		/// <returns>
+		/// Slug created from <see cref="text"/>
+		/// </returns>
+		public virtual string Create(string text)
+		{
+			return Create(text, this.whitespaceReplacement, this.replacementPatterns, this.toLower);
+		}
+
+		/// <summary>
+		/// Verifies if slug is properly formatted
+		/// Implementation is combination of .Net Uri.IsWellFormedUriString used for
+		/// checking of encoding, and recommendations from RFC 3986 [http://tools.ietf.org/html/rfc3986]
+		/// The generic syntax uses the slash ("/"), question mark ("?"), and
+		/// number sign ("#") characters to delimit components
+		/// </summary>
+		/// <param name="slug">Slug to be tested</param>
+		/// <returns>True if slug is valid, false otherwise</returns>
+		public virtual bool IsValid(string slug)
+		{
+			if (String.IsNullOrWhiteSpace(slug))
+			{
+				return false;
+			}
+			else
+			{
+				return slug.IndexOfAny(new[] { '/', '?', '#', '@', ':', '&', '+', '\'', '*' }) == -1
+					&& !slug.Contains("%20") // space encoded in name is confusing N2 url parser
+					&& Uri.IsWellFormedUriString(slug, UriKind.Relative);
+			}
+		}
+
+		/// <summary>
+		/// Creates slug from text
+		/// </summary>
+		/// <param name="text">
+		/// Text to be converted to slug
+		/// </param>
+		/// <param name="whitespaceReplacement">
+		/// Whitespace replacement character
+		/// </param>
+		/// <param name="replacementPatterns">
+		/// Set of custom patterns for replacing characters
+		/// </param>
+		/// <param name="toLower">
+		/// True if produced slug should be lowercase
+		/// </param>
+		/// <returns>
+		/// Slug generated from <see cref="text"/>.
+		/// </returns>
+		private static string Create(
+			string text,
+			char whitespaceReplacement,
+			PatternValueCollection replacementPatterns,
+			bool toLower)
+		{
+			if (string.IsNullOrWhiteSpace(text))
+			{
+				return string.Empty;
+			}
+
+			foreach (PatternValueElement pattern in replacementPatterns)
+			{
+				text = Regex.Replace(text, pattern.Pattern, pattern.Value);
+			}
+
+			string normalised = text.Normalize(NormalizationForm.FormKD);
+
+			const int Maxlen = 80;
+			int len = normalised.Length;
+			bool prevDash = false;
+			var sb = new StringBuilder(len);
+			char c;
+
+			for (int i = 0; i < len; i++)
+			{
+				c = normalised[i];
+				if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'))
+				{
+					if (prevDash)
+					{
+						sb.Append('-');
+						prevDash = false;
+					}
+
+					sb.Append(c);
+				}
+				else if (c >= 'A' && c <= 'Z')
+				{
+					if (prevDash)
+					{
+						sb.Append('-');
+						prevDash = false;
+					}
+
+					// tricky way to convert to lowercase
+					if (toLower)
+					{
+						sb.Append((char)(c | 32));
+					}
+					else
+					{
+						sb.Append(c);
+					}
+				}
+				else if (c == ' ' || c == ',' || c == '.' || c == '/' || c == '\\' || c == '-' || c == '_' || c == '=')
+				{
+					if (!prevDash && sb.Length > 0)
+					{
+						prevDash = true;
+					}
+				}
+				else
+				{
+					string swap = ConvertEdgeCases(c, toLower);
+
+					if (swap != null)
+					{
+						if (prevDash)
+						{
+							sb.Append('-');
+							prevDash = false;
+						}
+
+						sb.Append(swap);
+					}
+				}
+
+				if (sb.Length == Maxlen)
+				{
+					break;
+				}
+			}
+
+			string slug = sb.ToString();
+
+			if (whitespaceReplacement != '-')
+			{
+				return slug.Replace('-', whitespaceReplacement);
+			}
+			else
+			{
+				return slug;
+			}
+		}
+
+		/// <summary>
+		/// Helper method for converting special cases not covered by Normalize method
+		/// </summary>
+		/// <param name="c">
+		/// Character to be converted
+		/// </param>
+		/// <param name="toLower">
+		/// Should character be converted to lowercase
+		/// </param>
+		/// <returns>
+		/// Converted value
+		/// </returns>
+		private static string ConvertEdgeCases(char c, bool toLower)
+		{
+			string swap = null;
+			switch (c)
+			{
+				case 'ı':
+					swap = "i";
+					break;
+				case 'ł':
+					swap = "l";
+					break;
+				case 'Ł':
+					swap = toLower ? "l" : "L";
+					break;
+				case 'đ':
+					swap = "d";
+					break;
+				case 'Đ':
+					swap = toLower ? "d" : "D";
+					break;
+				case 'ß':
+					swap = "ss";
+					break;
+				case 'ø':
+					swap = "o";
+					break;
+				case 'Ø':
+					swap = toLower ? "o" : "O";
+					break;
+				case 'Þ':
+					swap = "th";
+					break;
+			}
+
+			return swap;
+		}
+	}
+}

--- a/src/Framework/N2/Web/UI/WebControls/NameEditor.cs
+++ b/src/Framework/N2/Web/UI/WebControls/NameEditor.cs
@@ -15,7 +15,8 @@ namespace N2.Web.UI.WebControls
 	public class NameEditor : CompositeControl, IValidator, ITextControl
 	{
 		static NameEditorElement config;
-		
+
+		private Slug slug;
 		private CheckBox keepUpdated = new CheckBox();
 		private TextBox editor = new TextBox();
 		private bool? showKeepUpdated;
@@ -32,6 +33,7 @@ namespace N2.Web.UI.WebControls
 		{
 			editor.MaxLength = 250;
 			CssClass = "nameEditor";
+			slug = N2.Context.Current.Resolve<Slug>();
 		}
 
 		public static NameEditorElement Config
@@ -242,17 +244,8 @@ namespace N2.Web.UI.WebControls
 						return;
 					}
 
-					foreach(PatternValueElement element in Config.Replacements.AllElements)
-					{
-						if(element.ServerValidate && Regex.IsMatch(Text, element.Pattern, RegexOptions.Compiled))
-						{
-							ErrorMessage = InvalidCharactersErrorFormat;
-							IsValid = false;
-							return;
-						}
-					}
-
-					if(Text.IndexOfAny(new char[]{'?', '&', '/', '+', ':', '%'}) >= 0)
+					// Check validity of slug
+					if (!this.slug.IsValid(Text))
 					{
 						ErrorMessage = InvalidCharactersErrorFormat;
 						IsValid = false;

--- a/src/Framework/Tests/N2.Tests.csproj
+++ b/src/Framework/Tests/N2.Tests.csproj
@@ -256,6 +256,7 @@
     <Compile Include="Persistence\Sources\ContentSourceTests.cs" />
     <Compile Include="Plugin\Scheduling\Actions.cs" />
     <Compile Include="Types.cs" />
+    <Compile Include="Web\SlugTests.cs" />
     <Compile Include="Web\UrlParser_IUrlSource_VirtualDirectory.cs" />
     <Compile Include="Web\UrlParser_IUrlSource_MultipleSites.cs" />
     <Compile Include="Web\Items\UrlSourcePage.cs" />
@@ -455,7 +456,9 @@
     <Compile Include="Workflow\SHould.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Framework/Tests/Web/SlugTests.cs
+++ b/src/Framework/Tests/Web/SlugTests.cs
@@ -1,0 +1,351 @@
+﻿using N2.Configuration;
+using N2.Web;
+using NUnit.Framework;
+
+namespace N2.Tests.Web
+{
+	[TestFixture]
+	public class SlugTests
+	{
+		private Slug caseInvariantSlug;
+		private Slug lowercaseSlug;
+		private Slug defaultSlug;
+		private Slug customReplacementSlug;
+
+		private Slug CreateCaseInvariantSlug()
+		{
+			NameEditorElement nameEditorElement = new NameEditorElement
+			{
+				WhitespaceReplacement = '-',
+				Replacements = new PatternValueCollection(),
+				ToLower = false
+			};
+
+			EditSection editSection = new EditSection { NameEditor = nameEditorElement };
+
+			ConfigurationManagerWrapper cmw = new ConfigurationManagerWrapper
+			{
+				Sections = new ConfigurationManagerWrapper.ContentSectionTable(null, null, null, editSection)
+			};
+
+			return new Slug(cmw);
+		}
+
+		private Slug CreateLowercaseSlug()
+		{
+			NameEditorElement nameEditorElement = new NameEditorElement
+			{
+				WhitespaceReplacement = '-',
+				Replacements = new PatternValueCollection(),
+				ToLower = true
+			};
+
+			EditSection editSection = new EditSection { NameEditor = nameEditorElement };
+
+			ConfigurationManagerWrapper cmw = new ConfigurationManagerWrapper
+			{
+				Sections = new ConfigurationManagerWrapper.ContentSectionTable(null, null, null, editSection)
+			};
+
+			return new Slug(cmw);
+		}
+
+		private Slug CreateDefaultSlug()
+		{
+			NameEditorElement nameEditorElement = new NameEditorElement();
+			EditSection editSection = new EditSection { NameEditor = nameEditorElement };
+
+			ConfigurationManagerWrapper cmw = new ConfigurationManagerWrapper
+			{
+				Sections = new ConfigurationManagerWrapper.ContentSectionTable(null, null, null, editSection)
+			};
+
+			return new Slug(cmw);
+		}
+
+		private Slug CreateCustomReplacementSlug()
+		{
+			PatternValueCollection patterns = new PatternValueCollection();
+			patterns.Clear(); // to remove all those added by constructor
+			patterns.Add(new PatternValueElement("c1", "[@]", "at", true));
+
+			NameEditorElement nameEditorElement = new NameEditorElement
+			{
+				// WhitespaceReplacement = '-',
+				Replacements = patterns //,
+				// ToLower = true
+			};
+
+			EditSection editSection = new EditSection { NameEditor = nameEditorElement };
+
+			ConfigurationManagerWrapper cmw = new ConfigurationManagerWrapper
+			{
+				Sections = new ConfigurationManagerWrapper.ContentSectionTable(null, null, null, editSection)
+			};
+
+			return new Slug(cmw);
+		}
+
+		[TestFixtureSetUp]
+		public void TestFixtureSetUp()
+		{
+			this.caseInvariantSlug = this.CreateCaseInvariantSlug();
+			this.lowercaseSlug = this.CreateLowercaseSlug();
+			this.defaultSlug = this.CreateDefaultSlug();
+			this.customReplacementSlug = this.CreateCustomReplacementSlug();
+		}
+
+		[TestCase("", "")]
+		public void Create_Should_Handle_Edge_Cases(string value, string expected)
+		{
+			string result = this.defaultSlug.Create(value);
+			Assert.AreEqual(expected, result);			
+		}
+
+		[TestCase("ṃ,ỹ,ṛ,è,ş,ư,ḿ,ĕ", "m-y-r-e-s-u-m-e")]
+		[TestCase("á-é-í-ó-ú", "a-e-i-o-u")]
+		[TestCase("à,å,á,â,ã,å,ą", "a-a-a-a-a-a-a")]
+		[TestCase("ä", "ae")]
+		[TestCase("è,é,ê,ë,ę", "e-e-e-e-e")]
+		[TestCase("ì,í,î,ï,ı", "i-i-i-i-i")]
+		[TestCase("ò,ó,ô,õ,ø", "o-o-o-o-o")]
+		[TestCase("ö", "oe")]
+		[TestCase("ù,ú,û", "u-u-u")]
+		[TestCase("ü", "ue")]
+		[TestCase("ç,ć,č", "c-c-c")]
+		[TestCase("ż,ź,ž", "z-z-z")]
+		[TestCase("ś,ş,š", "s-s-s")]
+		[TestCase("ñ,ń", "n-n")]
+		[TestCase("ý,Ÿ", "y-Y")]
+		[TestCase("ł,Ł", "l-L")]
+		[TestCase("đ", "d")]
+		[TestCase("ß", "ss")]
+		[TestCase("ğ", "g")]
+		[TestCase("Þ", "th")]
+		public void Create_Should_Remove_Accents_Case_Invariant(string value, string expected)
+		{
+			string result = this.caseInvariantSlug.Create(value);
+			Assert.AreEqual(expected, result);
+		}
+
+		[TestCase("ý,Ÿ", "y-y")]
+		[TestCase("ł,Ł", "l-l")]
+		[TestCase("Đ,đ", "d-d")]
+		public void Create_Should_Remove_Accents_To_Lower(string value, string expected)
+		{
+			string result = this.lowercaseSlug.Create(value);
+			Assert.AreEqual(expected, result);
+		}
+
+		[TestCase("Slug Me ", "slug-me")]
+		[TestCase("Slug Me,", "slug-me")]
+		[TestCase("Slug Me.", "slug-me")]
+		[TestCase("Slug Me/", "slug-me")]
+		[TestCase("Slug Me\\", "slug-me")]
+		[TestCase("Slug Me-", "slug-me")]
+		[TestCase("Slug Me_", "slug-me")]
+		[TestCase("Slug Me=", "slug-me")]
+		[TestCase("Slug Me--", "slug-me")]
+		[TestCase("Slug Me---,", "slug-me")]
+		public void Create_Should_Remove_Trailing_Punctuation(string value, string expected)
+		{
+			string result = this.defaultSlug.Create(value);
+			Assert.AreEqual(expected, result);
+		}
+
+		[TestCase("å,á,à,â,ã", "a-a-a-a-a")]
+		[TestCase("@", "a")]
+		[TestCase("Å,Á,À,Â,Ã", "A-A-A-A-A")]
+		[TestCase("æ,ä", "ae-ae")]
+		[TestCase("Æ,Ä", "Ae-Ae")]
+		[TestCase("é,è", "e-e")]
+		[TestCase("É,È", "E-E")]
+		[TestCase("í,ì", "i-i")]
+		[TestCase("Í,Ì", "I-I")]
+		[TestCase("ø,ó,ò,ô,õ", "o-o-o-o-o")]
+		[TestCase("Ø,Ó,Ò,Ô,Õ", "O-O-O-O-O")]
+		[TestCase("ú,ù", "u-u")]
+		[TestCase("Ú,Ù", "U-U")]
+		[TestCase("ü", "ue")]
+		[TestCase("Ü", "Ue")]
+		[TestCase("ß", "ss")]
+		public void Create_Should_Keep_CaseInvariant_Compatibility_With_Old_N2_Slug_Implementation(string value, string expected)
+		{
+			string result = this.caseInvariantSlug.Create(value);
+			Assert.AreEqual(expected, result);
+		}	
+		
+		[TestCase("å,á,à,â,ã", "a-a-a-a-a")]
+		[TestCase("@", "a")]
+		[TestCase("Å,Á,À,Â,Ã", "a-a-a-a-a")]
+		[TestCase("æ,ä", "ae-ae")]
+		[TestCase("Æ,Ä", "ae-ae")]
+		[TestCase("é,è", "e-e")]
+		[TestCase("É,È", "e-e")]
+		[TestCase("í,ì", "i-i")]
+		[TestCase("Í,Ì", "i-i")]
+		[TestCase("ø,ó,ò,ô,õ", "o-o-o-o-o")]
+		[TestCase("Ø,Ó,Ò,Ô,Õ", "o-o-o-o-o")]
+		[TestCase("ú,ù", "u-u")]
+		[TestCase("Ú,Ù", "u-u")]
+		[TestCase("ü", "ue")]
+		[TestCase("Ü", "ue")]
+		[TestCase("ß", "ss")]
+		public void Create_Should_Keep_Lowercase_Compatibility_With_Old_N2_Slug_Implementation(string value, string expected)
+		{
+			string result = this.lowercaseSlug.Create(value);
+			Assert.AreEqual(expected, result);
+		}
+
+		[TestCase("@", "at")]
+		public void Create_Should_Apply_Config_Replacements(string value, string expected)
+		{
+			var result = this.customReplacementSlug.Create(value);
+			Assert.AreEqual(expected, result);			
+		}
+
+		[TestCase("abc")]
+		[TestCase("abc%def")]
+		[TestCase("abc-def")]
+		[TestCase("abc_def")]
+		[TestCase("abc.def")]
+		[TestCase("abc~def")]
+		[TestCase("abc!def")]
+		[TestCase("abc$def")]
+		[TestCase("abc()def")]
+		[TestCase("abc,def")]
+		[TestCase("abc;def")]
+		[TestCase("abc=def")]
+		public void IsValid_Should_Accept_Valid_Slugs(string value)
+		{
+			Assert.True(this.defaultSlug.IsValid(value));
+		}
+
+		[TestCase("abc def")]
+		[TestCase("abc%20def")]
+		[TestCase("abc+def")]
+		[TestCase("abc\\")]
+		[TestCase("abc#")]
+		[TestCase("abc?")]
+		[TestCase("abc[]")]
+		[TestCase("abc%")]
+		[TestCase("abc%x")]
+		[TestCase("abc%xx")]
+		[TestCase("abc@")]
+		[TestCase("abc&def")]
+		[TestCase("abc'def")]
+		[TestCase("abc*def")]
+		public void IsValid_Should_Refuse_Invalid_Slugs(string value)
+		{
+			Assert.False(this.defaultSlug.IsValid(value));			
+		}
+
+		[TestCase(":")]
+		[TestCase("abc:")]
+		[TestCase("abc:def")]
+		[TestCase(":def")]
+		[TestCase("abc:80")]
+		[TestCase("/")]
+		[TestCase("abc/")]
+		[TestCase("abc/def")]
+		[TestCase("/def")]
+		[TestCase("?")]
+		[TestCase("abc?")]
+		[TestCase("abc?def")]
+		[TestCase("?def")]
+		[TestCase("#")]
+		[TestCase("abc#")]
+		[TestCase("abc#def")]
+		[TestCase("#def")]
+		[TestCase("[")]
+		[TestCase("abc[")]
+		[TestCase("abc[def")]
+		[TestCase("[def")]
+		[TestCase("]")]
+		[TestCase("abc]")]
+		[TestCase("abc]def")]
+		[TestCase("]def")]
+		[TestCase("@")]
+		[TestCase("abc@")]
+		[TestCase("abc@def")]
+		[TestCase("@def")]
+		[TestCase("&")]
+		[TestCase("abc&")]
+		[TestCase("abc&def")]
+		[TestCase("&def")]
+		[TestCase("+")]
+		[TestCase("abc+")]
+		[TestCase("abc+def")]
+		[TestCase("+def")]
+		[TestCase("'")]
+		[TestCase("abc'")]
+		[TestCase("abc'def")]
+		[TestCase("'def")]
+		[TestCase("*")]
+		[TestCase("abc*")]
+		[TestCase("abc*def")]
+		[TestCase("*def")]
+		public void IsValid_Should_Refuse_GenDelims_And_Ampersand_And_Plus_And_Apostrophe_And_Star(string value)
+		{
+			// based on rfc3986
+			// gen-delims  = ":" / "/" / "?" / "#" / "[" / "]" / "@"
+
+			Assert.False(this.defaultSlug.IsValid(value));
+		}
+
+		[TestCase("!")]
+		[TestCase("abc!")]
+		[TestCase("abc!def")]
+		[TestCase("!def")]
+		[TestCase("$")]
+		[TestCase("abc$")]
+		[TestCase("abc$def")]
+		[TestCase("$def")]
+		[TestCase("(")]
+		[TestCase("abc(")]
+		[TestCase("abc(def")]
+		[TestCase("(def")]
+		[TestCase(")")]
+		[TestCase("abc)")]
+		[TestCase("abc)def")]
+		[TestCase(")def")]
+		[TestCase(",")]
+		[TestCase("abc,")]
+		[TestCase("abc,def")]
+		[TestCase(",def")]
+		[TestCase(";")]
+		[TestCase("abc;")]
+		[TestCase("abc;def")]
+		[TestCase(";def")]
+		[TestCase("=")]
+		[TestCase("abc=")]
+		[TestCase("abc=def")]
+		[TestCase("=def")]
+		public void IsValid_Should_Accept_SubDelims_Without_Ampersand_Without_Plus_Without_Apostrophe_Without_Star(string value)
+		{
+			// based on rfc3986
+			// sub-delims  = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+
+			Assert.True(this.defaultSlug.IsValid(value));
+		}
+
+		[TestCase("my-pageђ")]
+		[TestCase("my-pageš")]
+		[TestCase("žmy-page")]
+		[TestCase("mđy-page")]
+		public void IsValid_Should_Reject_NonEnglish_Letters(string value)
+		{
+			Assert.False(this.defaultSlug.IsValid(value));
+		}
+
+		[TestCase("MySlug")]
+		[TestCase("My-Slug")]
+		[TestCase("my-Slug")]
+		[TestCase("my-SluG")]
+		[TestCase("My-SluG")]
+		public void IsValid_Should_Accept_Mixed_Capitals_And_Small_Letters(string value)
+		{
+			Assert.True(this.defaultSlug.IsValid(value));
+		}
+	}
+}

--- a/src/Mvc/MvcTemplates/N2/Resources/Js/plugins/jquery.n2name.js
+++ b/src/Mvc/MvcTemplates/N2/Resources/Js/plugins/jquery.n2name.js
@@ -6,15 +6,28 @@
     function getName(titleid, whitespace, tolower, replacements){
         var titleBox=document.getElementById(titleid);
 		if (!titleBox) return null;
-        var name = titleBox.value.replace(/[.]+/g, '-')
-	        .replace(/[%?&/+:<>]/g, '')
-	        .replace(/\s+/g, whitespace)
-	        .replace(/[-]+/g, '-')
-	        .replace(/[-]+$/g, '');
-        if(tolower) name = name.toLowerCase();
-        for (var i in replacements){
-	        name = name.replace(replacements[i].pattern, replacements[i].value);
-        }
+	    var name;
+
+        $.ajax({
+        	type: 'POST',
+        	async: false,
+        	cache: false,
+        	url: '/sluggenerator.n2.ashx',
+        	data: { action: "sluggenerator", title: titleBox.value },
+        	success: function (result) { name = result; },
+        	error: function () {
+        		name = titleBox.value.replace(/[.]+/g, '-')
+        		    .replace(/[%?&/+:<>]/g, '')
+        		    .replace(/\s+/g, whitespace)
+        		    .replace(/[-]+/g, '-')
+        		    .replace(/[-]+$/g, '');
+        		if(tolower) name = name.toLowerCase();
+        		for (var i in replacements){
+        			name = name.replace(replacements[i].pattern, replacements[i].value);
+        		}        		
+        	}
+        });
+
         return name;
     };
     


### PR DESCRIPTION
Slug generation, previously implemented via JS code is now replaced with C# service
1. Ajax call to c# code
2. Slug generation based on modified code used on Stack Overflow
3. Slug verification implemented according to RFC standard
4. Unit tests added
5. Several slugs that were fatal to N2 are no longer possible (like "a b" or "a%20b")
6. It is now possible to implement replacement service for any custom implementation that might be needed
