### PR TITLE
Fix the runtime issue with GetDataItemsByIds method in EditableItemSelectionAttribute

### DIFF
--- a/src/Framework/N2/Details/EditableItemSelectionAttribute.cs
+++ b/src/Framework/N2/Details/EditableItemSelectionAttribute.cs
@@ -1,178 +1,174 @@
-﻿using System;
+﻿using N2.Definitions;
+using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
-using System.Text;
-using N2.Persistence;
+using System.Web.UI.WebControls;
 using Parameter = N2.Persistence.Parameter;
 using ParameterCollection = N2.Persistence.ParameterCollection;
-using System.Globalization;
-using System.Web.UI.WebControls;
-using N2.Persistence.NH;
-using NHibernate.Linq;
-using N2.Definitions;
 
 namespace N2.Details
 {
-	/// <summary>
-	/// Allows selecting zero or more items of a specific type from an exapandable check box list.
-	/// </summary>
-	/// <example>
-	/// 	[EditableItemSelection]
-	/// 	public virtual IEnumerable&gt;ContentItem&lt; Links { get; set; }
-	/// </example>
-	[AttributeUsage(AttributeTargets.Property)]
-	public class EditableItemSelectionAttribute : EditableDropDownAttribute
-	{
-		public Type LinkedType { get; set; }
-		public Type ExcludedType { get; set; }
-		public int SearchTreshold { get; set; }
-		public EditableItemSelectionFilter Include { get; set; }
+    /// <summary>
+    /// Allows selecting zero or more items of a specific type from an exapandable check box list.
+    /// </summary>
+    /// <example>
+    /// 	[EditableItemSelection]
+    /// 	public virtual IEnumerable&gt;ContentItem&lt; Links { get; set; }
+    /// </example>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class EditableItemSelectionAttribute : EditableDropDownAttribute
+    {
+        public Type LinkedType { get; set; }
+        public Type ExcludedType { get; set; }
+        public int SearchTreshold { get; set; }
+        public EditableItemSelectionFilter Include { get; set; }
 
-		public EditableItemSelectionAttribute()
-		{
-			LinkedType = typeof(ContentItem);
-			ExcludedType = typeof(ISystemNode);
-			SearchTreshold = 20;
-			Include = EditableItemSelectionFilter.Pages;
-		}
+        public EditableItemSelectionAttribute()
+        {
+            LinkedType = typeof(ContentItem);
+            ExcludedType = typeof(ISystemNode);
+            SearchTreshold = 20;
+            Include = EditableItemSelectionFilter.Pages;
+        }
 
-		public EditableItemSelectionAttribute(Type linkedType)
-			: this()
-		{
-			LinkedType = linkedType;
-		}
+        public EditableItemSelectionAttribute(Type linkedType)
+            : this()
+        {
+            LinkedType = linkedType;
+        }
 
-		public EditableItemSelectionAttribute(Type linkedType, string title, int sortOrder)
-			: this()
-		{
-			Title = title;
-			SortOrder = sortOrder;
-		}
+        public EditableItemSelectionAttribute(Type linkedType, string title, int sortOrder)
+            : this()
+        {
+            Title = title;
+            SortOrder = sortOrder;
+        }
 
-		protected override string GetValue(ContentItem item)
-		{
-			return item.ID.ToString(CultureInfo.InvariantCulture);
-		}
+        protected override string GetValue(ContentItem item)
+        {
+            return item.ID.ToString(CultureInfo.InvariantCulture);
+        }
 
-		protected override object ConvertToValue(string value)
-		{
-			int id;
-			if (!int.TryParse(value, out id))
-			{
-				throw new Exception(string.Format("Invalid id: {0}", value));
-			}
+        protected override object ConvertToValue(string value)
+        {
+            int id;
+            if (!int.TryParse(value, out id))
+            {
+                throw new Exception(string.Format("Invalid id: {0}", value));
+            }
 
-			return id;
-		}
+            return id;
+        }
 
-		protected override ListItem[] GetListItems()
-		{
-			ParameterCollection query = Parameter.Equal("State", ContentState.Published);
+        protected override ListItem[] GetListItems()
+        {
+            ParameterCollection query = Parameter.Equal("State", ContentState.Published);
 
-			if (LinkedType != null && LinkedType != typeof(ContentItem))
-				query &= Parameter.TypeEqual(LinkedType);
+            if (LinkedType != null && LinkedType != typeof(ContentItem))
+                query &= Parameter.TypeEqual(LinkedType);
 
-			if (ExcludedType != null)
-				query &= Parameter.TypeNotEqual(ExcludedType);
+            if (ExcludedType != null)
+                query &= Parameter.TypeNotEqual(ExcludedType);
 
-			if (!Is(EditableItemSelectionFilter.Pages))
-				query &= Parameter.IsNotNull("ZoneName");
-			if (!Is(EditableItemSelectionFilter.Parts))
-				query &= Parameter.IsNull("ZoneName");
+            if (!Is(EditableItemSelectionFilter.Pages))
+                query &= Parameter.IsNotNull("ZoneName");
+            if (!Is(EditableItemSelectionFilter.Parts))
+                query &= Parameter.IsNull("ZoneName");
 
-			var items = Engine.Content.Search.Repository.Select(query, "ID", "Title");
+            var items = Engine.Content.Search.Repository.Select(query, "ID", "Title");
 
-			return items.Select(row => new ListItem((string)row["Title"], row["ID"].ToString()))
-				.ToArray();
-		}
+            return items.Select(row => new ListItem((string)row["Title"], row["ID"].ToString()))
+                .ToArray();
+        }
 
-		private bool Is(EditableItemSelectionFilter filter)
-		{
-			return (filter & Include) == filter;
-		}
+        private bool Is(EditableItemSelectionFilter filter)
+        {
+            return (filter & Include) == filter;
+        }
 
-		protected virtual IEnumerable<ContentItem> GetDataItemsByIds(params int[] ids)
-		{
-			if (ids == null || ids.Length == 0)
-				return Enumerable.Empty<ContentItem>();
+        protected virtual IEnumerable<ContentItem> GetDataItemsByIds(params int[] ids)
+        {
+            if (ids == null || ids.Length == 0)
+                return Enumerable.Empty<ContentItem>();
 
-			var items = Engine.Content.Search.Repository.Find(Parameter.In("ID", ids));
+            var items = Engine.Content.Search.Repository.Find(Parameter.In("ID", ids.Select(id => (object)id).ToArray()));
 
-			return items;
-		}
+            return items;
+        }
 
-		public override void UpdateEditor(ContentItem item, System.Web.UI.Control editor)
-		{
-			var linkedItems = GetStoredSelection(item);
+        public override void UpdateEditor(ContentItem item, System.Web.UI.Control editor)
+        {
+            var linkedItems = GetStoredSelection(item);
 
-			var checkboxList = editor as ListControl;
-			if (checkboxList == null) return;
+            var checkboxList = editor as ListControl;
+            if (checkboxList == null) return;
 
-			foreach (ListItem checkboxItem in checkboxList.Items)
-			{
-				int checkboxValue;
-				if (int.TryParse(checkboxItem.Value, out checkboxValue))
-				{
-					checkboxItem.Selected = linkedItems.Contains(checkboxValue);
-				}
-			}
-		}
+            foreach (ListItem checkboxItem in checkboxList.Items)
+            {
+                int checkboxValue;
+                if (int.TryParse(checkboxItem.Value, out checkboxValue))
+                {
+                    checkboxItem.Selected = linkedItems.Contains(checkboxValue);
+                }
+            }
+        }
 
-		public override bool UpdateItem(ContentItem item, System.Web.UI.Control editor)
-		{
-			var checkboxList = editor as ListControl;
-			if (checkboxList == null) return false;
+        public override bool UpdateItem(ContentItem item, System.Web.UI.Control editor)
+        {
+            var checkboxList = editor as ListControl;
+            if (checkboxList == null) return false;
 
-			// Get a map of currently linked items
-			var storedItems = GetStoredSelection(item);
+            // Get a map of currently linked items
+            var storedItems = GetStoredSelection(item);
 
-			// Get a map of all selected items from UI
-			var selectedLinkedItems = (from ListItem checkboxItem in checkboxList.Items
-																 where checkboxItem.Selected
-																 where !string.IsNullOrEmpty(checkboxItem.Value)
-																 select (int)ConvertToValue(checkboxItem.Value)).ToArray();
+            // Get a map of all selected items from UI
+            var selectedLinkedItems = (from ListItem checkboxItem in checkboxList.Items
+                                       where checkboxItem.Selected
+                                       where !string.IsNullOrEmpty(checkboxItem.Value)
+                                       select (int)ConvertToValue(checkboxItem.Value)).ToArray();
 
-			// Check whether there were any changes
-			var hasChanges = storedItems.All(selectedLinkedItems.Contains) == false
-				|| selectedLinkedItems.All(storedItems.Contains) == false 
-				|| storedItems.Count != selectedLinkedItems.Length;
+            // Check whether there were any changes
+            var hasChanges = storedItems.All(selectedLinkedItems.Contains) == false
+                || selectedLinkedItems.All(storedItems.Contains) == false
+                || storedItems.Count != selectedLinkedItems.Length;
 
-			// Only hook up items when there were changes
-			if (hasChanges)
-			{
-				// Convert id array to ContentItems
-				var linksToAdd = GetDataItemsByIds(selectedLinkedItems);
+            // Only hook up items when there were changes
+            if (hasChanges)
+            {
+                // Convert id array to ContentItems
+                var linksToAdd = GetDataItemsByIds(selectedLinkedItems);
 
-				ReplaceStoredValue(item, linksToAdd);
-			}
+                ReplaceStoredValue(item, linksToAdd);
+            }
 
-			return hasChanges;
-		}
+            return hasChanges;
+        }
 
-		protected virtual void ReplaceStoredValue(ContentItem item, IEnumerable<ContentItem> linksToReplace)
-		{
-			item[Name] = linksToReplace.FirstOrDefault();
-		}
+        protected virtual void ReplaceStoredValue(ContentItem item, IEnumerable<ContentItem> linksToReplace)
+        {
+            item[Name] = linksToReplace.FirstOrDefault();
+        }
 
-		protected virtual HashSet<int> GetStoredSelection(ContentItem item)
-		{
-			var storedSelection = new HashSet<int>();
-			
-			var referencedItem = item[Name] as ContentItem;
-			if (referencedItem != null)
-				storedSelection.Add(referencedItem.ID);
+        protected virtual HashSet<int> GetStoredSelection(ContentItem item)
+        {
+            var storedSelection = new HashSet<int>();
 
-			return storedSelection;
-		}
+            var referencedItem = item[Name] as ContentItem;
+            if (referencedItem != null)
+                storedSelection.Add(referencedItem.ID);
 
-		public override void Write(ContentItem item, string propertyName, System.IO.TextWriter writer)
-		{
-			var referencedItem = item[propertyName] as ContentItem;
+            return storedSelection;
+        }
 
-			if (referencedItem != null)
-			{
-				DisplayableAnchorAttribute.GetLinkBuilder(item, referencedItem, propertyName, null, null).WriteTo(writer);
-			}
-		}
-	}
+        public override void Write(ContentItem item, string propertyName, System.IO.TextWriter writer)
+        {
+            var referencedItem = item[propertyName] as ContentItem;
+
+            if (referencedItem != null)
+            {
+                DisplayableAnchorAttribute.GetLinkBuilder(item, referencedItem, propertyName, null, null).WriteTo(writer);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fix the issue with GetDataItemsByIds method in EditableItemSelectionAttribute.

The issue is when Parameter.In is being called, since the second parameter is "param object[] anyOf" it takes the integer array as the first item in the object[] instead of converting it to an array of objects that causes runtime error.

More information about param object[] in the following page, http://msdn.microsoft.com/en-us/library/w5zay9db.aspx

Please note that the diff file is big because it is showing some whitespace changes, the meat of the change is the following line.

var items = Engine.Content.Search.Repository.Find(Parameter.In("ID", ids.Select(id => (object)id).ToArray()));
