### PR TITLE
Prevent browser cache when adding children to content items

### DIFF
--- a/src/Framework/N2/Edit/Api/ContentHandler.cs
+++ b/src/Framework/N2/Edit/Api/ContentHandler.cs
@@ -44,6 +44,8 @@ namespace N2.Management.Api
 			if (!engine.SecurityManager.IsAuthorized(context.User, Selection.SelectedItem, Security.Permission.Read))
 				throw new UnauthorizedAccessException();
 
+		    CacheUtility.SetNoCache(context.Response);
+
 			switch (context.Request.HttpMethod)
 			{
 				case "GET":

--- a/src/Framework/N2/Web/CacheUtility.cs
+++ b/src/Framework/N2/Web/CacheUtility.cs
@@ -54,6 +54,18 @@ namespace N2.Web
 			return false;
 		}
 
+        /// <summary>
+        /// Updates response cache settings to prevent client caching
+        /// </summary>
+        /// <param name="response">The response whose cache to modify.</param>
+        public static void SetNoCache(this HttpResponseBase response)
+        {
+            response.Cache.SetCacheability(HttpCacheability.NoCache);
+            response.Cache.SetRevalidation(HttpCacheRevalidation.AllCaches);
+            response.Cache.SetLastModified(DateTime.UtcNow);
+            response.Cache.SetMaxAge(new TimeSpan(0));
+        }
+
 		/// <summary>Sets public cacheablility (ask server if resources is modified) on the response header.</summary>
 		/// <param name="response">The response whose cache to modify.</param>
 		/// <param name="expirationTime">The time before the resource expires.</param>


### PR DESCRIPTION
Some browsers (ahem, IE) cache more aggressively and using angular js $resource fails to get new content when making AJAX requests.   

When adding new child content items, IE fails to update the list of children in the N2 admin left nav list.

This fix adds a "cache busting" parameter when fetching children from the content service to ensure that the new items show up immediately and the user isn't all "where's the thing I just created?".
