### PR TITLE
Rename Content resource delete method to remove to ensure works in IE8

### DIFF
--- a/src/Mvc/MvcTemplates/N2/App/Js/Controllers.js
+++ b/src/Mvc/MvcTemplates/N2/App/Js/Controllers.js
@@ -394,7 +394,7 @@ function MenuCtrl($rootScope, $scope, Security) {
 function PageActionCtrl($scope, Content) {
 	$scope.dispose = function () {
 		console.log("disposing", $scope.Context.CurrentItem);
-		Content.delete({ selected: $scope.Context.CurrentItem.Path }, function () {
+		Content.remove({ selected: $scope.Context.CurrentItem.Path }, function () {
 			$scope.reloadChildren(getParentPath($scope.Context.CurrentItem.Path));
 			console.log("disposed");
 		});

--- a/src/Mvc/MvcTemplates/N2/App/Js/Services.js
+++ b/src/Mvc/MvcTemplates/N2/App/Js/Services.js
@@ -85,7 +85,7 @@
 			'definitions': { method: 'GET', params: { target: 'definitions' } },
 			'move': { method: 'POST', params: { target: 'move' } },
 			'sort': { method: 'POST', params: { target: 'sort' } },
-			'delete': { method: 'POST', params: { target: 'delete' } },
+			'remove': { method: 'POST', params: { target: 'delete' } },
 			'publish': { method: 'POST', params: { target: 'publish' } },
 			'unpublish': { method: 'POST', params: { target: 'unpublish' } },
 			'schedule': { method: 'POST', params: { target: 'schedule' } }


### PR DESCRIPTION
Since delete is a reserved keyword and IE is dumb, IE8 breaks on loading the management interface.

I've changed the 'delete' method on the Content $resource to use 'remove' instead.  This ensures that it will still work in IE8...
