### PR TITLE
ckEditor not working with nuget package - fix

### DIFF
--- a/docs/n2cms.configuration.xsd
+++ b/docs/n2cms.configuration.xsd
@@ -566,6 +566,7 @@
                   <xs:attribute name="overwriteFormatTags" type="xs:string" use="optional" default="p;h1;h2;h3;pre" />
                   <xs:attribute name="contentsCssPath" type="xs:string" use="optional" default="~/N2/Resources/ckeditor/contents.css" />
                   <xs:attribute name="advancedMenus" type="xs:boolean" use="optional" default="false" />
+                  <xs:attribute name="overwriteLanguage" type="xs:string" use="optional" default="en" />
 								</xs:complexType>
 							</xs:element>
 							<xs:element name="tinyMCE" minOccurs="0">

--- a/src/Framework/N2/Configuration/CkEditorElement.cs
+++ b/src/Framework/N2/Configuration/CkEditorElement.cs
@@ -45,5 +45,12 @@ namespace N2.Configuration
 			get { return (bool)base["advancedMenus"]; }
 			set { base["advancedMenus"] = value; }
 		}
+
+		[ConfigurationProperty("overwriteLanguage")]
+		public string OverwriteLanguage
+		{
+			get { return (string)base["overwriteLanguage"]; }
+			set { base["overwriteLanguage"] = value; }
+		}
 	}
 }

--- a/src/Framework/N2/Web/UI/WebControls/FreeTextArea.cs
+++ b/src/Framework/N2/Web/UI/WebControls/FreeTextArea.cs
@@ -30,6 +30,7 @@ namespace N2.Web.UI.WebControls
 		static string configJsPath = string.Empty;
 		static string overwriteStylesSet = string.Empty;
 		static string overwriteFormatTags = string.Empty;
+		static string overwriteLanguage = string.Empty;
 		private EditorModeSetting editorMode = EditorModeSetting.Standard;
 		private string additionalFormats = string.Empty;
 		private string useStylesSet = string.Empty;
@@ -86,6 +87,7 @@ namespace N2.Web.UI.WebControls
 					configJsPath = Url.ResolveTokens(config.CkEditor.ConfigJsPath );
 					overwriteStylesSet = Url.ResolveTokens(config.CkEditor.OverwriteStylesSet);
 					overwriteFormatTags = config.CkEditor.OverwriteFormatTags;
+					overwriteLanguage = config.CkEditor.OverwriteLanguage;
 					contentCssUrl = Url.ResolveTokens(config.CkEditor.ContentsCssPath);
 					advancedMenues = config.CkEditor.AdvancedMenus;
 				}
@@ -131,9 +133,22 @@ namespace N2.Web.UI.WebControls
 			overrides["filebrowserFlashBrowseUrl"] = overrides["filebrowserImageBrowseUrl"];
 
 
+
 			string language = System.Threading.Thread.CurrentThread.CurrentUICulture.TwoLetterISOLanguageName;
+
+			if (!string.IsNullOrEmpty(overwriteLanguage))
+				language = overwriteLanguage;
+
 			if (HostingEnvironment.VirtualPathProvider.FileExists(Url.ResolveTokens("{ManagementUrl}/Resources/ckeditor/lang/" + language + ".js")))
+			{
 				overrides["language"] = language;
+			}
+			else
+			{
+				overrides["language"] = "en";
+			}
+
+		
 
 			if (!string.IsNullOrEmpty(DocumentBaseUrl))
 				overrides["baseHref"] = Page.ResolveUrl(DocumentBaseUrl);
@@ -150,7 +165,6 @@ namespace N2.Web.UI.WebControls
 
 			if (!string.IsNullOrEmpty(useStylesSet))
 				overrides["stylesSet"] = useStylesSet;
-
 
 
 			if (!string.IsNullOrEmpty(overwriteFormatTags))


### PR DESCRIPTION
ckEditor not working with nuget package - fix

I've found the reason why ckeditor isn't working with nuget package (http://n2cms.codeplex.com/discussions/450462)

I had the problem with different n2cms versions, too. While working on the ckeditor configration options pull request this bug doesn't occur. Now i've upgraded a project to version 2.5.6.1 with nuget and i had the error again. 

After a lot of time searching, i used fiddler to analyze the traffic and found the error. Ckeditor tried  to load the de.js file which wasn't in the nuget package. Ckeditor should fall back to en if the language file isn't found. But this doesn't work. At first i added the ckeditor defaultLanguage option, but i had the same result. So i've modified the FreeTextArea to fall back, if the language file isn't found. 
And while working on the fix i decided to add an option which could be used to set the language. 
