### PR TITLE
Fix exception when finding user by email and user does not have one set.

### DIFF
--- a/src/Mvc/MvcTemplates/N2/Security/ContentMembershipProvider.cs
+++ b/src/Mvc/MvcTemplates/N2/Security/ContentMembershipProvider.cs
@@ -420,7 +420,9 @@ namespace N2.Security
 				return null;
 
 			var users = Bridge.Repository.Find(Parameter.TypeEqual(typeof(User).Name) & Parameter.Equal("Parent", userContainer)).ToList();
-			var userNames = users.Where(x => x.Details["Email"].ToString().Equals(email, StringComparison.OrdinalIgnoreCase)).Select(x => x.Name);
+
+            // default admin account does not have an email field be default, to test first.
+			var userNames = users.Where(x => x.Details.ContainsKey("Email") && x.Details["Email"].ToString().Equals(email, StringComparison.OrdinalIgnoreCase)).Select(x => x.Name);
 
 			return userNames.FirstOrDefault();
 		}


### PR DESCRIPTION
Exception occurred when calling GetUserNameByEmail when it hit the admin user as there was no email set.
