### PR TITLE
Enable use of value types as for models.

### DIFF
--- a/src/Framework/Razor/Web/Mvc/ContentWebViewPageOfT.cs
+++ b/src/Framework/Razor/Web/Mvc/ContentWebViewPageOfT.cs
@@ -7,7 +7,7 @@ using System.Web.Mvc;
 namespace N2.Web.Mvc
 {
 	/// <remarks>This code is here since it has dependencies on ASP.NET 3.0 which isn't a requirement for N2 in general.</remarks>
-	public abstract class ContentWebViewPage<TModel> : WebViewPage<TModel>, IContentView where TModel : class
+	public abstract class ContentWebViewPage<TModel> : WebViewPage<TModel>, IContentView
 	{
 		private DynamicContentHelper content;
 


### PR DESCRIPTION
The model class restriction prevents the creation of editor and display templates for value types, which prevents adding a date picker as show in this example: http://www.asp.net/mvc/tutorials/javascript/using-the-html5-and-jquery-ui-datepicker-popup-calendar-with-aspnet-mvc/using-the-html5-and-jquery-ui-datepicker-popup-calendar-with-aspnet-mvc-part-4

<!---
@huboard:{"order":287.96875}
-->
