### PR TITLE
Use GetSafeHtml instead of HtmlEncode from ISafeContentRenderer

### DIFF
--- a/src/Framework/N2/Edit/NodeAdapter.cs
+++ b/src/Framework/N2/Edit/NodeAdapter.cs
@@ -111,7 +111,7 @@ namespace N2.Edit
 				State = item.State,
 				IconUrl = GetIconUrl(item),
 				IconClass = GetIconClass(item),
-				Title = Engine.Resolve<ISafeContentRenderer>().HtmlEncode(item.Title),
+				Title = Engine.Resolve<ISafeContentRenderer>().GetSafeHtml(item.Title),
 				ToolTip = "#" + item.ID + ": " +  Definitions.GetDefinition(item).Title,
 				PreviewUrl = GetPreviewUrl(item, allowDraft: allowDraft),
 				MaximumPermission = GetMaximumPermission(item),


### PR DESCRIPTION
In #400 there was an issue with html encoding titles that was used in AngularJs data binding. Angular does its own encoding, so Murciélago would render double escaped. 
Now uses ISafeContentRendered.GetSafeHtml() instead.
Links to #362
