### PR TITLE
Support RequiresUniqueEmail better

### DIFF
--- a/src/Mvc/MvcTemplates/N2/Security/ContentMembershipProvider.cs
+++ b/src/Mvc/MvcTemplates/N2/Security/ContentMembershipProvider.cs
@@ -264,7 +264,8 @@ namespace N2.Security
                     u.IsLogin = true;
             }
 
-            if (requiresUniqueEmail)
+			//access the property, not the field, in case overriden by a subclass
+            if (RequiresUniqueEmail) 
             {
                 if(!string.IsNullOrEmpty(GetUserNameByEmail(email))){
                     status = MembershipCreateStatus.DuplicateEmail;


### PR DESCRIPTION
In your CreateUser, you access the private field requiresUniqueUser instead of the virtual read-only property, which could be overridden in a subclass. (Of course you need to be careful about doing that and might want to override GetUserByEmail to throw an exception, but we should allow users to subclass correctly here, and avoid using private fields when virtual properties exist.)
