### PR TITLE
Allow separation between drop points when parts have float.

### DIFF
--- a/src/Mvc/MvcTemplates/N2/Resources/Css/Parts.css
+++ b/src/Mvc/MvcTemplates/N2/Resources/Css/Parts.css
@@ -22,7 +22,7 @@
 .dragging .titleBar { display:none; }
 
 /* hide/show droppables */
-.dropPoint { position:relative; background-color:#cec; border:solid 1px #efe; margin:-1px 0; }
+.dropPoint { position:relative; background-color:#cec; border:solid 1px #efe; margin:-1px 0; clear: both; }
 	.dropPoint .description { font-size:9px; padding:0 3px;  }
 .dragging .dragShadow { cursor:move; }
 .dragged { outline:dotted 1px #c33; }


### PR DESCRIPTION
When using parts have have a style of `float: left`, the drop points all bunch together and don't stack before and after the parts. By setting the `clear: both` style on the drop points, they then stack before and after parts that are floated in layout. 
