### PR TITLE
Display definition title when content item has no title

### DIFF
--- a/src/Mvc/MvcTemplates/N2/Content/Edit.aspx.cs
+++ b/src/Mvc/MvcTemplates/N2/Content/Edit.aspx.cs
@@ -293,10 +293,11 @@ namespace N2.Edit
 
 		private void InitTitle()
 		{
+			ItemDefinition definition = Definitions.GetDefinition(ie.CurrentItemType);
+			string definitionTitle = GetGlobalResourceString("Definitions", definition.Discriminator + ".Title") ?? definition.Title;
+
 			if (ie.CurrentItem.ID == 0 && !ie.CurrentItem.VersionOf.HasValue)
 			{
-				ItemDefinition definition = Definitions.GetDefinition(ie.CurrentItemType);
-				string definitionTitle = GetGlobalResourceString("Definitions", definition.Discriminator + ".Title") ?? definition.Title;
 				string format = GetLocalResourceString("EditPage.TitleFormat.New", "New \"{0}\"");
 
 				string template = Request["template"];
@@ -312,7 +313,7 @@ namespace N2.Edit
 			else
 			{
 				string format = GetLocalResourceString("EditPage.TitleFormat.Update", "Edit \"{0}\"");
-				Title = string.Format(format, ie.CurrentItem.Title);
+				Title = string.Format(format, string.IsNullOrEmpty(ie.CurrentItem.Title) ? definitionTitle : ie.CurrentItem.Title);
 			}
 		}
 

--- a/src/Mvc/MvcTemplates/N2/Web/UI/Controls/ItemLink.cs
+++ b/src/Mvc/MvcTemplates/N2/Web/UI/Controls/ItemLink.cs
@@ -33,17 +33,19 @@ namespace N2.Edit.Web.UI.Controls
             else
                 this.NavigateUrl = InterfaceUrl.ResolveUrlTokens().ToUrl().AppendSelection(item);
 
+            var title = string.IsNullOrEmpty(item.Title) ? N2.Context.Current.Definitions.GetDefinition(item).Title : item.Title;
+
             if (!ShowIcon)
             {
-                Text = item.Title;
+                Text = title;
             }
             else if (string.IsNullOrEmpty(item.IconUrl))
             {
-                Text = string.Format("<b class='{0}'></b> {1}", item.IconClass, item.Title);
+                Text = string.Format("<b class='{0}'></b> {1}", item.IconClass, title);
             }
             else
             {
-                Text = string.Format("<img src='{0}' alt='{1}' /> {2}", item.IconUrl.ResolveUrlTokens(), item.GetContentType().Name, string.IsNullOrEmpty(item.Title) ? "(untitled)" : item.Title);
+                Text = string.Format("<img src='{0}' alt='{1}' /> {2}", item.IconUrl.ResolveUrlTokens(), item.GetContentType().Name, title);
             }
         }
     }


### PR DESCRIPTION
When editing a content item with a null or empty string `Title` property, the editor currently displays the header:

> Edit ""

Let's fall back to the title from the definition instead, similar to how the header is rendered when adding a new content item. Example:

> Edit "Analytics Tracking Code"

A similar change is provided for the `ItemLink` control, allowing fall back to definition title in the right hand side listing of children in zones.
