### PR TITLE
[FIX] If a page doesnt have a language it returns null in the inner.GetL...

### DIFF
--- a/src/Framework/N2/Engine/Globalization/CachingLanguageGatewayDecorator.cs
+++ b/src/Framework/N2/Engine/Globalization/CachingLanguageGatewayDecorator.cs
@@ -68,9 +68,13 @@ namespace N2.Engine.Globalization
             if (cache.LanguageItems.TryGetValue(item.ID, out language))
                 return language;
 
-            language = GetLanguage(inner.GetLanguage(item).LanguageCode);
+            var innerLanguage = inner.GetLanguage(item);
+
+            if (innerLanguage == null) return null;
+
+            language = GetLanguage(innerLanguage.LanguageCode);
             cache.LanguageItems = new Dictionary<int, ILanguage>(cache.LanguageItems) { { item.ID, language } };
-            
+
             return inner.GetLanguage(item);
         }
 
@@ -81,8 +85,11 @@ namespace N2.Engine.Globalization
             ILanguage language;
             if (cache.LanguageCodes.TryGetValue(languageCode, out language))
                 return language;
+            var innerLanguage = inner.GetLanguage(languageCode);
 
-            language = new Language(inner.GetLanguage(languageCode));
+            if (innerLanguage == null) return null;
+
+            language = new Language(innerLanguage);
             cache.LanguageCodes = new Dictionary<string, ILanguage>(cache.LanguageCodes) { { languageCode, language } };
             return language;
         }
@@ -119,13 +126,13 @@ namespace N2.Engine.Globalization
 
         private LanguageCache GetLanguageCache()
         {
-            var cache =  cacheWrapper.Get<LanguageCache>("CachingLanguageGatewayDecorator_" + masterKey);
+            var cache = cacheWrapper.Get<LanguageCache>("CachingLanguageGatewayDecorator_" + masterKey);
             if (cache == null)
             {
-                cache = new LanguageCache 
-                { 
-                    LanguageCodes = new Dictionary<string, ILanguage>(), 
-                    LanguageItems = new Dictionary<int, ILanguage>() 
+                cache = new LanguageCache
+                {
+                    LanguageCodes = new Dictionary<string, ILanguage>(),
+                    LanguageItems = new Dictionary<int, ILanguage>()
                 };
                 cacheWrapper.Add("CachingLanguageGatewayDecorator_" + masterKey, cache, new CacheOptions { SlidingExpiration = slidingExpiration });
             }


### PR DESCRIPTION
...anguage and that results in a Object Ref in the CachingLanguageGateway, So added an check so it checks if its null and return null cause that's fine. This problem is happening for example when access an languageIntersaction
