### PR TITLE
[FIX] Directory: AddTo() needs to call ClearUrl()

### DIFF
--- a/src/Mvc/MvcTemplates/N2/Files/FileSystem/Pages/Directory.cs
+++ b/src/Mvc/MvcTemplates/N2/Files/FileSystem/Pages/Directory.cs
@@ -89,6 +89,8 @@ namespace N2.Edit.FileSystem.Items
                     FileSystem.CreateDirectory(to);
 
                 Parent = newParent;
+
+                ClearUrl();
             }
             else if (newParent != null)
             {


### PR DESCRIPTION
If not LocalUrl will contain an old incorrect value.
