### PR TITLE
[FIX] Index may not be less than 0

### DIFF
--- a/src/Framework/N2/Collections/ContentListOfT.cs
+++ b/src/Framework/N2/Collections/ContentListOfT.cs
@@ -76,7 +76,7 @@ namespace N2.Collections
 
         public void Insert(int index, T item)
         {
-            Inner.Insert(index, item);
+            Inner.Insert(Math.Max(0,index), item);
         }
 
         public void RemoveAt(int index)


### PR DESCRIPTION
In some cases its -1 when moving folders or files around in the file
system and that causes an unwanted exception. This is maybe a dirty fix.
