### PR TITLE
#614 - Allow Pages with RestrictCardinality to be reordered.

### DIFF
--- a/src/Framework/N2/Definitions/AllowedDefinitionQuery.cs
+++ b/src/Framework/N2/Definitions/AllowedDefinitionQuery.cs
@@ -5,6 +5,7 @@ namespace N2.Definitions
         public IDefinitionManager Definitions { get; set; }
         public ContentItem Parent { get; set; }
         public ItemDefinition ParentDefinition { get; set; }
+        public ContentItem Child { get; set; }
         public ItemDefinition ChildDefinition { get; set; }
     }
 }

--- a/src/Framework/N2/Definitions/DefinitionExtensions.cs
+++ b/src/Framework/N2/Definitions/DefinitionExtensions.cs
@@ -15,11 +15,11 @@ namespace N2.Definitions
             return allSecurable.Where(s => security.IsAuthorized(s, user, parentItem));
         }
 
-        public static IEnumerable<ItemDefinition> AllowedBelow(this IEnumerable<ItemDefinition> allDefinitions, ItemDefinition parentDefinition, ContentItem parentItem, IDefinitionManager definitions)
+        public static IEnumerable<ItemDefinition> AllowedBelow(this IEnumerable<ItemDefinition> allDefinitions, ItemDefinition parentDefinition, ContentItem parentItem, ContentItem childItem, IDefinitionManager definitions)
         {
             foreach (var definition in allDefinitions)
             {
-                if (IsAllowed(definition, parentItem, parentDefinition, definitions))
+                if (IsAllowed(childItem, definition, parentItem, parentDefinition, definitions))
                     yield return definition;
             }
         }
@@ -28,15 +28,15 @@ namespace N2.Definitions
         {
             foreach (var template in allTemplates)
             {
-                if (IsAllowed(template.Definition, parentItem, parentDefinition, definitions))
+                if (IsAllowed(null, template.Definition, parentItem, parentDefinition, definitions))
                     yield return template;
             }
         }
 
-        private static bool IsAllowed(ItemDefinition definition, ContentItem parentItem, ItemDefinition parentDefinition, IDefinitionManager definitions)
+        private static bool IsAllowed(ContentItem childItem, ItemDefinition childDefinition, ContentItem parentItem, ItemDefinition parentDefinition, IDefinitionManager definitions)
         {
-            var ctx = new AllowedDefinitionQuery { Parent = parentItem, ParentDefinition = parentDefinition, ChildDefinition = definition, Definitions = definitions };
-            var filters = parentDefinition.AllowedChildFilters.Union(definition.AllowedParentFilters).ToList();
+            var ctx = new AllowedDefinitionQuery { Parent = parentItem, ParentDefinition = parentDefinition, Child = childItem, ChildDefinition = childDefinition, Definitions = definitions };
+            var filters = parentDefinition.AllowedChildFilters.Union(childDefinition.AllowedParentFilters).ToList();
             if (filters.Any(f => f.IsAllowed(ctx) == AllowedDefinitionResult.Allow))
                 // filter specificly allows -> allow
                 return true;

--- a/src/Framework/N2/Definitions/ItemDefinition.cs
+++ b/src/Framework/N2/Definitions/ItemDefinition.cs
@@ -211,12 +211,25 @@ namespace N2.Definitions
         /// <summary>Gets or sets additional child types allowed below this item.</summary>
         public IEnumerable<ItemDefinition> GetAllowedChildren(IDefinitionManager definitions, ContentItem parentItem)
         {
-            return definitions.GetDefinitions().AllowedBelow(this, parentItem, definitions);
+            return definitions.GetDefinitions().AllowedBelow(this, parentItem, null, definitions);
+        }
+
+        // Fixes #614 pages marked with RestrictCardinality cannot be sorted
+        /// <summary>Gets or sets additional child types allowed below this item.</summary>
+        public IEnumerable<ItemDefinition> GetAllowedChildren(IDefinitionManager definitions, ContentItem parentItem, ContentItem childItem)
+        {
+            return definitions.GetDefinitions().AllowedBelow(this, parentItem, childItem, definitions);
         }
 
         public bool IsChildAllowed(IDefinitionManager definitions, ContentItem parentItem, ItemDefinition childDefinition)
         {
             return GetAllowedChildren(definitions, parentItem).Any(d => d.ItemType == childDefinition.ItemType);
+        }
+
+        // Fixes #614 pages marked with RestrictCardinality cannot be sorted
+        public bool IsChildAllowed(IDefinitionManager definitions, ContentItem parentItem, ItemDefinition childDefinition, ContentItem childItem)
+        {
+            return GetAllowedChildren(definitions, parentItem, childItem).Any(d => d.ItemType == childDefinition.ItemType);
         }
 
         /// <summary>Find out if this item is allowed in a zone.</summary>

--- a/src/Framework/N2/Integrity/IntegrityManager.cs
+++ b/src/Framework/N2/Integrity/IntegrityManager.cs
@@ -220,7 +220,7 @@ namespace N2.Integrity
                 Definitions.ItemDefinition sourceDefinition = definitions.GetDefinition(source);
                 Definitions.ItemDefinition destinationDefinition = definitions.GetDefinition(destination);
 
-                return destinationDefinition.IsChildAllowed(definitions, destination, sourceDefinition);
+                return destinationDefinition.IsChildAllowed(definitions, destination, sourceDefinition, source);
             }
             return true;
         }

--- a/src/Framework/N2/Integrity/RestrictCardinalityAttribute.cs
+++ b/src/Framework/N2/Integrity/RestrictCardinalityAttribute.cs
@@ -36,7 +36,7 @@ namespace N2.Integrity
             if (query.Parent == null) return AllowedDefinitionResult.DontCare;
 
             var type = ComparableType ?? query.ChildDefinition.ItemType;
-            int childrenOfTypeCount = query.Parent.Children.Count(i => type.IsAssignableFrom(i.GetContentType()));
+            int childrenOfTypeCount = query.Parent.Children.Count(i => (query.Child == null || query.Child.ID != i.ID) && type.IsAssignableFrom(i.GetContentType()));
             if (childrenOfTypeCount >= MaximumCount)
                 return AllowedDefinitionResult.Deny;
 


### PR DESCRIPTION
A quick fix for Issue #614.

RestrictCardinality needs to know it's own ID so it can be excluded when sorting. This change provides overloaded ItemDefinition methods which are called by the IntegrityManager. This fixes drag-and-drop sorting through the web interface.

All other code paths use the pre-existing behaviour in the older methods.