### PR TITLE
VarybyHeader in CacheManager

### DIFF
--- a/src/Framework/N2/Configuration/OutputCacheElement.cs
+++ b/src/Framework/N2/Configuration/OutputCacheElement.cs
@@ -25,6 +25,12 @@ namespace N2.Configuration
             get { return (string)base["varyByParam"]; }
             set { base["varyByParam"] = value; }
         }
+        [ConfigurationProperty("varyByCustom", DefaultValue = "")]
+        public string VaryByCustom
+        {
+            get { return (string)base["varyByCustom"]; }
+            set { base["varyByCustom"] = value; }
+        }
 
         [ConfigurationProperty("cacheProfile")]
         public string CacheProfile

--- a/src/Framework/N2/Configuration/OutputCacheElement.cs
+++ b/src/Framework/N2/Configuration/OutputCacheElement.cs
@@ -26,7 +26,7 @@ namespace N2.Configuration
             set { base["varyByParam"] = value; }
         }
         [ConfigurationProperty("varyByCustom", DefaultValue = "")]
-        public string VaryByCustom
+        public string VaryByHeader
         {
             get { return (string)base["varyByCustom"]; }
             set { base["varyByCustom"] = value; }

--- a/src/Framework/N2/Web/UI/CacheManager.cs
+++ b/src/Framework/N2/Web/UI/CacheManager.cs
@@ -15,6 +15,7 @@ namespace N2.Web.UI
 
         bool enabled = false;
         string varyByParam = "*";
+        string varyByCustom = "";
         string cacheProfile = "";
         int duration = 60;
 
@@ -29,6 +30,7 @@ namespace N2.Web.UI
         {
             enabled = config.OutputCache.Enabled;
             varyByParam = config.OutputCache.VaryByParam;
+            varyByCustom = config.OutputCache.VaryByCustom;
             cacheProfile = config.OutputCache.CacheProfile;
             duration = config.OutputCache.Duration;
         }
@@ -71,6 +73,8 @@ namespace N2.Web.UI
             //parameters.VaryByControl = VaryByControl;
             //parameters.VaryByCustom = VaryByCustom;
             //parameters.VaryByHeader = VaryByHeader;
+            if (!string.IsNullOrEmpty(varyByCustom))
+                parameters.VaryByCustom = varyByCustom;
             parameters.VaryByParam = varyByParam;
             return parameters;
         }

--- a/src/Framework/N2/Web/UI/CacheManager.cs
+++ b/src/Framework/N2/Web/UI/CacheManager.cs
@@ -15,7 +15,7 @@ namespace N2.Web.UI
 
         bool enabled = false;
         string varyByParam = "*";
-        string varyByCustom = "";
+        string varyByHeader = "";
         string cacheProfile = "";
         int duration = 60;
 
@@ -30,7 +30,7 @@ namespace N2.Web.UI
         {
             enabled = config.OutputCache.Enabled;
             varyByParam = config.OutputCache.VaryByParam;
-            varyByCustom = config.OutputCache.VaryByCustom;
+            varyByHeader = config.OutputCache.VaryByHeader;
             cacheProfile = config.OutputCache.CacheProfile;
             duration = config.OutputCache.Duration;
         }
@@ -73,8 +73,8 @@ namespace N2.Web.UI
             //parameters.VaryByControl = VaryByControl;
             //parameters.VaryByCustom = VaryByCustom;
             //parameters.VaryByHeader = VaryByHeader;
-            if (!string.IsNullOrEmpty(varyByCustom))
-                parameters.VaryByCustom = varyByCustom;
+            if (!string.IsNullOrEmpty(varyByHeader))
+                parameters.VaryByHeader = varyByHeader;
             parameters.VaryByParam = varyByParam;
             return parameters;
         }


### PR DESCRIPTION
Hello,

we are using n2cms with multiple hostnames and when enabling outputcache=true, 

We get same content on different hostnames. I have added an fix so we can varybycustom.

Cause we have code that look like this

```
 public override string GetVaryByCustomString(HttpContext context, string custom)
        {
var returnString = "";
if (custom.Contains("host"))
            {
                returnString += "host=" + context.Request.Url.Host;
            }
return returnString;
}
```

And now we can just add in the web.config section n2 > outputcache > varyByCustom=host

Maybe it could be useful for someone ? 
Not sure why it was commented out ?