### PR TITLE
use HttpRuntime instead of Request to get ApplicationPath

### DIFF
--- a/src/Framework/Packaging/Web/Hosting/Util.cs
+++ b/src/Framework/Packaging/Web/Hosting/Util.cs
@@ -53,7 +53,7 @@ namespace SharpZipLib.Web.VirtualPathProvider
 
         private static string ToAppRelative(String virtualPath)
         {
-            if(HttpContext.Current == null || !virtualPath.StartsWith(HttpContext.Current.Request.ApplicationPath))
+            if(HttpContext.Current == null || !virtualPath.StartsWith(HttpRuntime.AppDomainAppVirtualPath))
                 return "~" + virtualPath;
 
             return VirtualPathUtility.ToAppRelative(virtualPath);


### PR DESCRIPTION
Use HttpRuntime.AppDomainAppVirtualPath instead of HttpContext.Current.Request.ApplicationPath to avoid "Request is not available in this context" exception because HttpContext.Current.Request is not available during Application Start in Integrated mode on IIS7