### PR TITLE
Fix language searching when using a full (hyphenated) language code.

### DIFF
--- a/src/Framework/Extensions.Tests/N2.Extensions.Tests.csproj
+++ b/src/Framework/Extensions.Tests/N2.Extensions.Tests.csproj
@@ -45,7 +45,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/src/Framework/Extensions.Tests/Search/LuceneSearchTests.cs
+++ b/src/Framework/Extensions.Tests/Search/LuceneSearchTests.cs
@@ -682,6 +682,48 @@ namespace N2.Extensions.Tests.Search
         }
 
         [Test]
+        public void Language_ByFullLanguageCode()
+        {
+            var sv = CreateOneItem<PersistableItem2>(2, "Svenska", root);
+            sv.LanguageCode = "sv-SE";
+            var en = CreateOneItem<PersistableItem2>(3, "Engelska", root);
+            en.LanguageCode = "en-GB";
+
+            var svitem = CreateOneItem<PersistableItem>(4, "Hello världen", sv);
+            indexer.Update(svitem);
+
+            var enitem = CreateOneItem<PersistableItem>(5, "Hello world", en);
+            indexer.Update(enitem);
+
+
+            var result = searcher.Search(Query.For("hello").Language(sv.LanguageCode));
+
+            Assert.That(result.Hits.Count(), Is.EqualTo(1));
+            Assert.That(result.Single(), Is.EqualTo(svitem));
+        }
+
+        [Test]
+        public void Language_ByPartialLanguageCode()
+        {
+            var sv = CreateOneItem<PersistableItem2>(2, "Svenska", root);
+            sv.LanguageCode = "sv-SE";
+            var en = CreateOneItem<PersistableItem2>(3, "Engelska", root);
+            en.LanguageCode = "en-GB";
+
+            var svitem = CreateOneItem<PersistableItem>(4, "Hello världen", sv);
+            indexer.Update(svitem);
+
+            var enitem = CreateOneItem<PersistableItem>(5, "Hello world", en);
+            indexer.Update(enitem);
+
+
+            var result = searcher.Search(Query.For("hello").Language("sv"));
+
+            Assert.That(result.Hits.Count(), Is.EqualTo(1));
+            Assert.That(result.Single(), Is.EqualTo(svitem));
+        }
+
+        [Test]
         public void Language_IncludesLanguageRoot()
         {
             var sv = CreateOneItem<PersistableItem2>(2, "Svenska", root);

--- a/src/Framework/N2/Persistence/Search/TextExtractor.cs
+++ b/src/Framework/N2/Persistence/Search/TextExtractor.cs
@@ -81,7 +81,7 @@ namespace N2.Persistence.Search
             doc.Add(Properties.IsPage, item.IsPage.ToString().ToLower(), store: true, analyze: false);
             doc.Add(Properties.Roles, GetRoles(item), store: true, analyze: true);
             doc.Add(Properties.Types, GetTypes(item), store: true, analyze: true);
-            doc.Add(Properties.Language, GetLanguage(item), store: true, analyze: false);
+            doc.Add(Properties.Language, GetLanguage(item), store: true, analyze: true);
             doc.Add(Properties.Visible, item.Visible.ToString().ToLower(), store: true, analyze: false);
             doc.Add(Properties.SortOrder, item.SortOrder, store: true, analyze: false);
 

--- a/src/Framework/Search.Lucene/LuceneAccesor.cs
+++ b/src/Framework/Search.Lucene/LuceneAccesor.cs
@@ -83,6 +83,7 @@ namespace N2.Persistence.Search
                     { "Roles", new WhitespaceAnalyzer() },
                     { "State", new WhitespaceAnalyzer() },
                     { "IsPage", new WhitespaceAnalyzer() },
+                    { "Language", new SimpleAnalyzer() }
                 });
         }
 


### PR DESCRIPTION
This change allows hyphenated language codes e.g. "en-GB" to be filtered correctly when searching.