### PR TITLE
JS executing before dom-ready, resource defaults and look&feel fix

### DIFF
--- a/src/Framework/N2/Web/UI/WebControls/MediaSelector.cs
+++ b/src/Framework/N2/Web/UI/WebControls/MediaSelector.cs
@@ -66,7 +66,7 @@ namespace N2.Web.UI.WebControls
 		protected virtual void RegisterClientScripts()
         {
             Page.JavaScript("n2MediaSelection.initializeEditableMedia();", 
-                ScriptPosition.Bottom, ScriptOptions.DocumentReady | ScriptOptions.ScriptTags);
+                ScriptPosition.Bottom, ScriptOptions.DocumentReady);
         }
 
         /// <summary>Initializes the UrlSelector control.</summary>

--- a/src/Mvc/MvcTemplates/N2/Content/Navigation/App_LocalResources/MediaBrowser.aspx.resx
+++ b/src/Mvc/MvcTemplates/N2/Content/Navigation/App_LocalResources/MediaBrowser.aspx.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
   <data name="Continue" xml:space="preserve">
     <value>Continue</value>
   </data>

--- a/src/Mvc/MvcTemplates/N2/Content/Navigation/MediaBrowser.aspx
+++ b/src/Mvc/MvcTemplates/N2/Content/Navigation/MediaBrowser.aspx
@@ -18,8 +18,8 @@
     <div id="fileBrowser-main-div" class="thumbs-div">
 
         <ul class="nav nav-tabs no-active-outline" id="tabsCtrl">
-            <li role="presentation" class="active"><a href="#0"><%= GetLocalResourceObject("TabsGallery") %></a></li>
-            <li role="presentation"><a href="#1"><%= GetLocalResourceObject("TabsUpload") %></a></li>
+            <li role="presentation" class="active"><a href="#0"><%= GetLocalResourceObject("TabsGallery") ?? "Gallery" %></a></li>
+            <li role="presentation"><a href="#1"><%= GetLocalResourceObject("TabsUpload") ?? "Upload file" %></a></li>
         </ul>
 
         <div id="browser-files-list" class="browser-files-section first browser-files-list">
@@ -27,7 +27,7 @@
             <div class="row files-search-cont">
                 <div class="col-sm-8 col-md-6">
                     <div class="input-group input-group-sm">
-                        <input type="text" id="input-group-q" class="form-control" placeholder="<%= GetLocalResourceObject("Search") %>" />
+                        <input type="text" id="input-group-q" class="form-control" placeholder="<%= GetLocalResourceObject("Search") ?? "Search..." %>" />
                         <span class="input-group-btn">
                             <button id="btn-search" class="btn btn-default" type="button"><span class="glyphicon glyphicon-search"></span></button>
                             <button id="btn-search-clean" class="btn btn-default" type="button"><span class="glyphicon glyphicon-remove"></span></button>
@@ -53,7 +53,7 @@
                 data-selurl="<%= Request["selectedUrl"]%>"
                 data-baseajax="<%= mediaBrowserModel.HandlerUrl %>" data-mediacontrol="<%= mediaBrowserModel.MediaControl %>"
                 data-ckeditor="<%= mediaBrowserModel.CkEditor %>" data-ckeditorfuncnum="<%= mediaBrowserModel.CkEditorFuncNum %>" data-preferredsize="<%= mediaBrowserModel.PreferredSize %>"
-                data-i18size="<%= GetLocalResourceObject("Size") %>" data-i18date="<%= GetLocalResourceObject("DateModified") %>" data-i18url="<%= GetLocalResourceObject("Url") %>">
+                data-i18size="<%= GetLocalResourceObject("Size") ?? "Size" %>" data-i18date="<%= GetLocalResourceObject("DateModified") ?? "Date" %>" data-i18url="<%= GetLocalResourceObject("Url") ?? "Url" %>">
                 <% if(mediaBrowserModel.Dirs!=null) foreach (var d in mediaBrowserModel.Dirs) { %>
                 <li data-i="<%= counter++ %>" class="dir" data-url="<%= d.Path %>">
                     <span class="file-ic glyphicon glyphicon-folder-open"></span>
@@ -92,7 +92,7 @@
         <div id="browser-upload-file" class="browser-files-section">
             <div class='file-selector-container'>
             
-                <button type="button" id="FileUploadItemId_Btn" class="btn btn-info" data-fire="FileUploadItem"><span class="glyphicon glyphicon-hdd"></span> <%= GetLocalResourceObject("SelectFiles") %></button>
+                <button type="button" id="FileUploadItemId_Btn" class="btn btn-info" data-fire="FileUploadItem"><span class="glyphicon glyphicon-hdd"></span> <%= GetLocalResourceObject("SelectFiles") ?? "Select files..." %></button>
 
                 <div class='file-selector-control'>
                     <input class="file-upload-ajax valid" data-valueid="FileUploadItemId" id="FileUploadItem" multiple="multiple" name="FileUploadItem" type="file" />
@@ -110,7 +110,7 @@
 
             </div>
             <div class="file-selector-disallowed">
-                <%= GetLocalResourceObject("UploadDisallowedBrowser") %>
+                <%= GetLocalResourceObject("UploadDisallowedBrowser") ?? "This browser is outdated and cannot upload files using this dialog. Please use a modern browser to get the most out of N2cms" %>
             </div>
         </div>
 
@@ -121,18 +121,18 @@
 
     <div id="browser-files-layover" class="browser-files-layover"></div>
     <div id="browser-files-layover-cont" class="browser-files-layover-cont">
-        <h1><%= GetLocalResourceObject("ExistingFiles") %></h1>
+        <h1><%= GetLocalResourceObject("ExistingFiles") ?? "Some files already exist in the server<br />What do you want to do with them?" %></h1>
         <ul id="browser-files-layover-ul"
-            data-i18keep="<%= GetLocalResourceObject("UploadKeepBoth")%>"
-            data-i18repl="<%= GetLocalResourceObject("UploadReplace")%>"
-            data-i18ignr="<%= GetLocalResourceObject("UploadIgnore")%>">
+            data-i18keep="<%= GetLocalResourceObject("UploadKeepBoth") ?? "Keep both" %>"
+            data-i18repl="<%= GetLocalResourceObject("UploadReplace") ?? "Replace" %>"
+            data-i18ignr="<%= GetLocalResourceObject("UploadIgnore") ?? "Ignore" %>">
         </ul>
-        <button type="button" id="btn-continue-upload" name="btn-continue-upload" class="btn btn-primary"><%= GetLocalResourceObject("Continue") %></button>
+        <button type="button" id="btn-continue-upload" name="btn-continue-upload" class="btn btn-primary"><%= GetLocalResourceObject("Continue") ?? "Continue" %></button>
     </div>
 
     <div class="framed-navbar navbar navbar-fixed-bottom">
         <div class="navbar-inner">
-            <button type="button" id="btn-select" name="btn-select" class="btn btn-primary" disabled="disabled"><%= GetLocalResourceObject("Select") %></button>
+            <button type="button" id="btn-select" name="btn-select" class="btn btn-primary" disabled="disabled"><%= GetLocalResourceObject("Select") ?? "Select" %></button>
             <button type="button" id="btn-cancel" name="btn-cancel command" class="btn btn-cancel"><%= GetLocalResourceObject("Cancel") ?? "Cancel" %></button>
         </div>
     </div>

--- a/src/Mvc/MvcTemplates/N2/Content/Navigation/MediaBrowser.aspx
+++ b/src/Mvc/MvcTemplates/N2/Content/Navigation/MediaBrowser.aspx
@@ -1,6 +1,7 @@
-﻿<%@ Page Language="C#" AutoEventWireup="true" CodeBehind="MediaBrowser.aspx.cs" Inherits="N2.Edit.Navigation.MediaBrowser" Trace="false" %>
+﻿<%@ Page Language="C#" AutoEventWireup="true" CodeBehind="MediaBrowser.aspx.cs" Inherits="N2.Edit.Navigation.MediaBrowser" Trace="false" Debug="true" %>
 <%@ Import Namespace="N2.Resources" %>
 <%@ Import Namespace="System.Linq" %>
+<%@ Import Namespace="System.Web.Configuration" %>
 
 <!DOCTYPE html>
 
@@ -18,8 +19,8 @@
     <div id="fileBrowser-main-div" class="thumbs-div">
 
         <ul class="nav nav-tabs no-active-outline" id="tabsCtrl">
-            <li role="presentation" class="active"><a href="#0"><%= GetLocalResourceObject("TabsGallery") ?? "Gallery" %></a></li>
-            <li role="presentation"><a href="#1"><%= GetLocalResourceObject("TabsUpload") ?? "Upload file" %></a></li>
+            <li role="presentation" class="active"><a href="#0"><asp:Literal runat="server" Text="Gallery" meta:resourceKey="TabsGallery" /></a></li>
+            <li role="presentation"><a href="#1"><asp:Literal runat="server" Text="Upload file" meta:resourceKey="TabsUpload" /></a></li>
         </ul>
 
         <div id="browser-files-list" class="browser-files-section first browser-files-list">
@@ -27,7 +28,7 @@
             <div class="row files-search-cont">
                 <div class="col-sm-8 col-md-6">
                     <div class="input-group input-group-sm">
-                        <input type="text" id="input-group-q" class="form-control" placeholder="<%= GetLocalResourceObject("Search") ?? "Search..." %>" />
+                        <input type="text" id="input-group-q" class="form-control" placeholder="<asp:Literal runat="server" Text="Search" meta:resourceKey="Search" />" />
                         <span class="input-group-btn">
                             <button id="btn-search" class="btn btn-default" type="button"><span class="glyphicon glyphicon-search"></span></button>
                             <button id="btn-search-clean" class="btn btn-default" type="button"><span class="glyphicon glyphicon-remove"></span></button>
@@ -53,7 +54,7 @@
                 data-selurl="<%= Request["selectedUrl"]%>"
                 data-baseajax="<%= mediaBrowserModel.HandlerUrl %>" data-mediacontrol="<%= mediaBrowserModel.MediaControl %>"
                 data-ckeditor="<%= mediaBrowserModel.CkEditor %>" data-ckeditorfuncnum="<%= mediaBrowserModel.CkEditorFuncNum %>" data-preferredsize="<%= mediaBrowserModel.PreferredSize %>"
-                data-i18size="<%= GetLocalResourceObject("Size") ?? "Size" %>" data-i18date="<%= GetLocalResourceObject("DateModified") ?? "Date" %>" data-i18url="<%= GetLocalResourceObject("Url") ?? "Url" %>">
+                data-i18size="<asp:Literal runat="server" Text="Size" meta:resourceKey="Size" />" data-i18date="<asp:Literal runat="server" Text="Date" meta:resourceKey="DateModified" />" data-i18url="<asp:Literal runat="server" Text="Url" meta:resourceKey="Url" />">
                 <% if(mediaBrowserModel.Dirs!=null) foreach (var d in mediaBrowserModel.Dirs) { %>
                 <li data-i="<%= counter++ %>" class="dir" data-url="<%= d.Path %>">
                     <span class="file-ic glyphicon glyphicon-folder-open"></span>
@@ -92,7 +93,7 @@
         <div id="browser-upload-file" class="browser-files-section">
             <div class='file-selector-container'>
             
-                <button type="button" id="FileUploadItemId_Btn" class="btn btn-info" data-fire="FileUploadItem"><span class="glyphicon glyphicon-hdd"></span> <%= GetLocalResourceObject("SelectFiles") ?? "Select files..." %></button>
+                <button type="button" id="FileUploadItemId_Btn" class="btn btn-info" data-fire="FileUploadItem"><span class="glyphicon glyphicon-hdd"></span> <asp:Literal runat="server" Text="Select files..." meta:resourceKey="SelectFiles" /></button>
 
                 <div class='file-selector-control'>
                     <input class="file-upload-ajax valid" data-valueid="FileUploadItemId" id="FileUploadItem" multiple="multiple" name="FileUploadItem" type="file" />
@@ -110,7 +111,7 @@
 
             </div>
             <div class="file-selector-disallowed">
-                <%= GetLocalResourceObject("UploadDisallowedBrowser") ?? "This browser is outdated and cannot upload files using this dialog. Please use a modern browser to get the most out of N2cms" %>
+                <asp:Literal runat="server" Text="This browser is outdated and cannot upload files using this dialog. Please use a modern browser to get the most out of N2cms" meta:resourceKey="UploadDisallowedBrowser" />
             </div>
         </div>
 
@@ -121,19 +122,19 @@
 
     <div id="browser-files-layover" class="browser-files-layover"></div>
     <div id="browser-files-layover-cont" class="browser-files-layover-cont">
-        <h1><%= GetLocalResourceObject("ExistingFiles") ?? "Some files already exist in the server<br />What do you want to do with them?" %></h1>
+        <h1><asp:Literal runat="server" Text="Some files already exist in the server<br />What do you want to do with them?" meta:resourceKey="ExistingFiles" /></h1>
         <ul id="browser-files-layover-ul"
-            data-i18keep="<%= GetLocalResourceObject("UploadKeepBoth") ?? "Keep both" %>"
-            data-i18repl="<%= GetLocalResourceObject("UploadReplace") ?? "Replace" %>"
-            data-i18ignr="<%= GetLocalResourceObject("UploadIgnore") ?? "Ignore" %>">
+            data-i18keep="<asp:Literal runat="server" Text="Keep both" meta:resourceKey="UploadKeepBoth" />"
+            data-i18repl="<asp:Literal runat="server" Text="Replace" meta:resourceKey="UploadReplace" />"
+            data-i18ignr="<asp:Literal runat="server" Text="Ignore" meta:resourceKey="UploadIgnore" />">
         </ul>
-        <button type="button" id="btn-continue-upload" name="btn-continue-upload" class="btn btn-primary"><%= GetLocalResourceObject("Continue") ?? "Continue" %></button>
+        <button type="button" id="btn-continue-upload" name="btn-continue-upload" class="btn btn-primary"><asp:Literal runat="server" Text="Continue" meta:resourceKey="Continue" /></button>
     </div>
 
     <div class="framed-navbar navbar navbar-fixed-bottom">
         <div class="navbar-inner">
-            <button type="button" id="btn-select" name="btn-select" class="btn btn-primary" disabled="disabled"><%= GetLocalResourceObject("Select") ?? "Select" %></button>
-            <button type="button" id="btn-cancel" name="btn-cancel command" class="btn btn-cancel"><%= GetLocalResourceObject("Cancel") ?? "Cancel" %></button>
+            <button type="button" id="btn-select" name="btn-select" class="btn btn-primary" disabled="disabled"><asp:Literal runat="server" Text="Select" meta:resourceKey="Select" /></button>
+            <button type="button" id="btn-cancel" name="btn-cancel command" class="btn btn-cancel"><asp:Literal runat="server" Text="Cancel" meta:resourceKey="Cancel" /></button>
         </div>
     </div>
 
@@ -141,6 +142,7 @@
         var tbid = '<%= HttpUtility.JavaScriptStringEncode(Request["tbid"])%>';
         var selectableExtensions = '<%= HttpUtility.JavaScriptStringEncode(Request["selectableExtensions"])%>';
         var ticket = '<%= FormsAuthentication.Encrypt(new FormsAuthenticationTicket("SecureUpload-" + Guid.NewGuid(), false, 60)) %>';
+		var maxSize = <%= (ConfigurationManager.GetSection("system.web/httpRuntime") as HttpRuntimeSection)!=null ? (ConfigurationManager.GetSection("system.web/httpRuntime") as HttpRuntimeSection).MaxRequestLength : -1 %>;
     </script>
 
 	<script type="text/javascript" src="<%= N2.Web.Url.ResolveTokens(Register.JQueryJsPath)%>"></script>

--- a/src/Mvc/MvcTemplates/N2/Content/Navigation/MediaBrowser.aspx
+++ b/src/Mvc/MvcTemplates/N2/Content/Navigation/MediaBrowser.aspx
@@ -1,4 +1,4 @@
-﻿<%@ Page Language="C#" AutoEventWireup="true" CodeBehind="MediaBrowser.aspx.cs" Inherits="N2.Edit.Navigation.MediaBrowser" Trace="false" Debug="true" %>
+﻿<%@ Page Language="C#" AutoEventWireup="true" CodeBehind="MediaBrowser.aspx.cs" Inherits="N2.Edit.Navigation.MediaBrowser" Trace="false" %>
 <%@ Import Namespace="N2.Resources" %>
 <%@ Import Namespace="System.Linq" %>
 <%@ Import Namespace="System.Web.Configuration" %>

--- a/src/Mvc/MvcTemplates/N2/Content/Navigation/MediaBrowser.js
+++ b/src/Mvc/MvcTemplates/N2/Content/Navigation/MediaBrowser.js
@@ -485,7 +485,8 @@
                 btnsSubmit,
                 qSel = document.querySelectorAll === undefined,
                 reqExists, arrNames = [], reqUpload, sNames, overwriteArr = [],
-                ajaxUrl = fileBrowser.ajaxUrl;
+                ajaxUrl = fileBrowser.ajaxUrl,
+                maxSizeMessage = "", maxSizeBytes = maxSize && maxSize > 0 ? maxSize * 1024 : 0;
 
             function saveContext() {
                 inputValueId = e.target.getAttribute("data-valueid");
@@ -514,6 +515,7 @@
                 datas = new FormData();
                 for (x = 0, len = files.length; x < len; x += 1) {
                     if (files[x].ignore) continue;
+                    if (maxSizeBytes > 0 && files[x].size > maxSizeBytes) continue;
                     datas.append("file" + kk, files[x]);
                     kk += 1;
                 }
@@ -623,8 +625,17 @@
                 if (window.FormData !== undefined) {
                     datas = new FormData();
                     for (x = 0, len = files.length; x < len; x += 1) {
-                        datas.append("file" + x, files[x]);
-                        arrNames.push(encodeURI(files[x].name));
+                        if (maxSizeBytes > 0 && files[x].size > maxSizeBytes) {
+                            maxSizeMessage += files[x].name + "\n";
+                        } else {
+                            datas.append("file" + x, files[x]);
+                            arrNames.push(encodeURI(files[x].name));
+                        }
+                    }
+
+                    if (maxSizeMessage) {
+                        alert("These files are bigger than the maximum allowed size for this site. Upload smaller files (" +
+                            (Math.round(maxSize / 1024 * 10) / 10) + " MBs) or ask your webmaster to increase the limit:\n\n" + maxSizeMessage);
                     }
 
                     saveContext();

--- a/src/Mvc/MvcTemplates/N2/Content/Navigation/MediaBrowserHandler.ashx.cs
+++ b/src/Mvc/MvcTemplates/N2/Content/Navigation/MediaBrowserHandler.ashx.cs
@@ -364,7 +364,7 @@ namespace N2.Edit.Navigation
                 {
                     Status = "Checked",
                     Files = (from fileName in fns
-                             let newPath = Url.Combine(context.Request.ApplicationPath + selected.Url, fileName)
+                             let newPath = Url.Combine(context.Request.ApplicationPath + selected.Url, HttpUtility.UrlDecode(fileName))
                              where FS.FileExists(newPath)
                              select fileName).ToArray()
                 });
@@ -434,9 +434,9 @@ namespace N2.Edit.Navigation
                 context.Response.WriteJson(new { Status = "Ok", Message = "Files uploaded" });
                 return;
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                context.Response.WriteJson(new { Status = "Error", Message = "Upload failed" });
+                context.Response.WriteJson(new { Status = "Error", Message = "Upload failed", Detail = e.Message });
                 return;
             }
 

--- a/src/Mvc/MvcTemplates/N2/Resources/Js/MediaSelection.js
+++ b/src/Mvc/MvcTemplates/N2/Resources/Js/MediaSelection.js
@@ -96,7 +96,7 @@ var n2MediaSelection = (function () {
         img = new Image();
 
         ovly.setAttribute("style", "position:fixed; top:0; left:0; right:0; bottom:0; background:#eee; background:rgba(235,235,235,0.8); z-index:20000;");
-        img.setAttribute("style", "position:absolute; top:5%; left:50%; max-width:90%; max-height:90%; width:auto; height:auto; display:block;");
+        img.setAttribute("style", "position:absolute; top:5%; left:5%; max-width:90%; max-height:90%; width:auto; height:auto; display:block;");
         noImg.setAttribute("style", "position:absolute; top:50%; left:50%; width:100px; height:50px; font-size:20px; color:#ff0000; margin:-25px 0 0 -50px;");
         close.setAttribute("style", "position:absolute; top:20px; right:20px; line-height:35px; height:40px; width:40px; color:black; font-size:30px; text-align:center; background:#ccc;z-index:10; border-radius:20px; cursor:pointer;");
 
@@ -110,8 +110,6 @@ var n2MediaSelection = (function () {
         ovly.id = "image-overlay";
 
         img.onload = function () {
-            var w = Math.round(this.width / 2);
-            img.style.marginLeft = (-w) + "px";
             ovly.appendChild(img);
         }
         img.onerror = function () {

--- a/src/Mvc/MvcTemplates/N2/Resources/Js/MediaSelection.js
+++ b/src/Mvc/MvcTemplates/N2/Resources/Js/MediaSelection.js
@@ -98,7 +98,7 @@ var n2MediaSelection = (function () {
         ovly.setAttribute("style", "position:fixed; top:0; left:0; right:0; bottom:0; background:#eee; background:rgba(235,235,235,0.8); z-index:20000;");
         img.setAttribute("style", "position:absolute; top:5%; left:50%; max-width:90%; max-height:90%; width:auto; height:auto; display:block;");
         noImg.setAttribute("style", "position:absolute; top:50%; left:50%; width:100px; height:50px; font-size:20px; color:#ff0000; margin:-25px 0 0 -50px;");
-        close.setAttribute("style", "position:absolute; top:20px; right:20px; line-height:40px; height:40px; width:40px; color:black; font-size:30px; text-align:center; background:#ccc;z-index:10; border-radius:20px; cursor:pointer;");
+        close.setAttribute("style", "position:absolute; top:20px; right:20px; line-height:35px; height:40px; width:40px; color:black; font-size:30px; text-align:center; background:#ccc;z-index:10; border-radius:20px; cursor:pointer;");
 
         close.innerHTML = "&times;"
         close.onclick = function (e) {


### PR DESCRIPTION
* Changed MediaSelector.cs to register script on ready (if not, too fast for webkit)
* Added default labels for local resources. 
* Improved the "close" button of the Media viewer.