### PR TITLE
N2.Persistence.MongoDB - MongoLinqQueryFacade

### DIFF
--- a/src/Framework/MongoDB/MongoLinqQueryFacade.cs
+++ b/src/Framework/MongoDB/MongoLinqQueryFacade.cs
@@ -1,0 +1,23 @@
+﻿using System.Linq;
+using MongoDB.Driver.Linq;
+using N2.Engine;
+using N2.Persistence.NH;
+
+namespace N2.Persistence.MongoDB
+{
+    [Service(typeof(LinqQueryFacade), Configuration = "mongo", Replaces = typeof(LinqNHQueryFacade))]
+    public class MongoLinqQueryFacade : LinqQueryFacade
+    {
+        private readonly MongoDatabaseProvider provider;
+
+        public MongoLinqQueryFacade(MongoDatabaseProvider provider)
+        {
+            this.provider = provider;
+        }
+
+        public override IQueryable<T> Query<T>()
+        {
+            return provider.GetCollection<ContentItem>().AsQueryable<T>();
+        }
+    }
+}

--- a/src/Framework/MongoDB/N2.Persistence.MongoDB.csproj
+++ b/src/Framework/MongoDB/N2.Persistence.MongoDB.csproj
@@ -72,6 +72,7 @@
     <Compile Include="MongoFileSystem.cs" />
     <Compile Include="MongoFinder.cs" />
     <Compile Include="MongoInstallationManager.cs" />
+    <Compile Include="MongoLinqQueryFacade.cs" />
     <Compile Include="MongoRepository.cs" />
     <Compile Include="RelationValueAccessorSerializer.cs" />
   </ItemGroup>


### PR DESCRIPTION
One powerful feature of N2CMS is to be able to to Linq queries against the documents but this feature seems missing in the MongoDB implementation. This commit implements LinqQueryFacade for MongoDB and makes it possible to do Linq queries when using MongoDB.

Example of usage:
var result = N2.Context.Current.Query<TextPage>().Where(x => x.Text.Contains("ToniMontana")).Where(new AllFilter(new AccessFilter(), new PublishedFilter()).Match).OrderByDescending(c => c.Updated).ToArray();