### PR TITLE
Added optional parameter for alt text to Content.Render.Image

### DIFF
--- a/src/Framework/Razor/Web/Mvc/Html/RenderExtensions.cs
+++ b/src/Framework/Razor/Web/Mvc/Html/RenderExtensions.cs
@@ -87,9 +87,9 @@ namespace N2.Web.Mvc.Html
         {
             return render.Displayable<DisplayableImageAttribute>(detailName);
         }
-        public static DisplayRenderer<DisplayableImageAttribute> Image(this RenderHelper render, string detailName, string preferredSize, string cssClass = null)
+        public static DisplayRenderer<DisplayableImageAttribute> Image(this RenderHelper render, string detailName, string preferredSize, string cssClass = null, string alt = null)
         {
-            return render.Displayable(new DisplayableImageAttribute { Name = detailName, PreferredSize = preferredSize, CssClass = cssClass ?? preferredSize });
+            return render.Displayable(new DisplayableImageAttribute { Name = detailName, PreferredSize = preferredSize, CssClass = cssClass ?? preferredSize, Alt = alt });
         }
 
         public static DisplayRenderer<DisplayableHeadingAttribute> Heading(this RenderHelper render, string detailName)


### PR DESCRIPTION
Added the ability to specify an alt text value when using Content.Render.Image so that you can use a value from a detail or some other expression.