### PR TITLE
Add autosave enable flag to config instead of hardcoded

### DIFF
--- a/src/Framework/N2/Configuration/AutosaveElement.cs
+++ b/src/Framework/N2/Configuration/AutosaveElement.cs
@@ -1,0 +1,14 @@
+﻿using System.Configuration;
+
+namespace N2.Configuration
+{
+    public class AutosaveElement : ConfigurationElement
+    {
+        [ConfigurationProperty("enabled", DefaultValue = true)]
+        public bool Enabled
+        {
+            get { return (bool)base["enabled"]; }
+            set { base["enabled"] = value; }
+        }
+    }
+}

--- a/src/Framework/N2/Configuration/EditSection.cs
+++ b/src/Framework/N2/Configuration/EditSection.cs
@@ -179,5 +179,12 @@ namespace N2.Configuration
 			get { return (OrganizeElement)base["organize"]; }
 			set { base["organize"] = value; }
 		}
-	}
+
+        [ConfigurationProperty("autosave")]
+        public AutosaveElement AutosaveElement
+        {
+            get { return (AutosaveElement)base["autosave"]; }
+            set { base["autosave"] = value; }
+        }
+    }
 }

--- a/src/Framework/N2/N2.csproj
+++ b/src/Framework/N2/N2.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Collections\IZonedListOfT.cs" />
     <Compile Include="Collections\TypeFilter.cs" />
     <Compile Include="Collections\ZoneFilter.cs" />
+    <Compile Include="Configuration\AutosaveElement.cs" />
     <Compile Include="Configuration\ChildrenElement.cs" />
     <Compile Include="Configuration\CkEditorElement.cs" />
     <Compile Include="Configuration\ClientElement.cs" />

--- a/src/Framework/N2/Web/UI/WebControls/ItemEditor.cs
+++ b/src/Framework/N2/Web/UI/WebControls/ItemEditor.cs
@@ -24,6 +24,7 @@ using N2.Persistence;
 using N2.Resources;
 using N2.Edit.Versioning;
 using System.Linq;
+using N2.Configuration;
 
 namespace N2.Web.UI.WebControls
 {
@@ -41,6 +42,7 @@ namespace N2.Web.UI.WebControls
         {
             CssClass = "itemEditor";
             Engine = N2.Context.Current;
+            EnableAutoSave = Engine.Resolve<EditSection>().AutosaveElement.Enabled;
         }
 
         public ItemEditor(ContentItem item)

--- a/src/Framework/Tests/Fakes/FakeEngine.cs
+++ b/src/Framework/Tests/Fakes/FakeEngine.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using N2.Configuration;
 using N2.Definitions;
 using N2.Edit;
 using N2.Engine;
@@ -47,6 +48,8 @@ namespace N2.Tests.Fakes
             var activator = new ContentActivator(new N2.Edit.Workflow.StateChanger(), new ItemNotifier(), proxyFactory);
             AddComponentInstance<ContentActivator>(activator);
             activator.Initialize(definitionManager.GetDefinitions());
+            var editSection = new EditSection();
+            AddComponentInstance<EditSection>(editSection);
         }
 
         #region IEngine Members

--- a/src/Mvc/MvcTemplates/N2/Content/Edit.aspx
+++ b/src/Mvc/MvcTemplates/N2/Content/Edit.aspx
@@ -45,7 +45,7 @@
 		    <asp:ValidationSummary ID="vsEdit" runat="server" CssClass="alert alert-warning alert-block alert-margin" HeaderText="The item couldn't be saved. Please look at the following:" meta:resourceKey="vsEdit"/>
 		    <asp:CustomValidator ID="cvException" runat="server" Display="None" />
 
-		    <n2:ItemEditor ID="ie" runat="server" EnableAutoSave="true" />
+		    <n2:ItemEditor ID="ie" runat="server"/>
 
 		    <div id="futurePanel" class="modal" tabindex="-1" role="dialog">
 			    <div class="modal-header">


### PR DESCRIPTION
As we had some problems with autosave a way to disable through the configs would be a nice thing to have.

If no config is added the behavior is as before but if you wish to disable the autosave this is now possible.