### PR TITLE
Add ng-non-bindable attribute to ItemEditorControl

### DIFF
--- a/src/Mvc/MvcTemplates/N2/Content/Edit.aspx
+++ b/src/Mvc/MvcTemplates/N2/Content/Edit.aspx
@@ -45,7 +45,7 @@
 		    <asp:ValidationSummary ID="vsEdit" runat="server" CssClass="alert alert-warning alert-block alert-margin" HeaderText="The item couldn't be saved. Please look at the following:" meta:resourceKey="vsEdit"/>
 		    <asp:CustomValidator ID="cvException" runat="server" Display="None" />
 
-		    <n2:ItemEditor ID="ie" runat="server"/>
+		    <n2:ItemEditor ID="ie" runat="server" ng-non-bindable/>
 
 		    <div id="futurePanel" class="modal" tabindex="-1" role="dialog">
 			    <div class="modal-header">


### PR DESCRIPTION
Currently we use {{}} as token replacers in our solution. When angular was added to N2 they started to get interpreted as angular expressions and the editors could not see them anymore. As far as I can see angular is not needed in the item editor fields and can therefore be set to non-bindable.