### PR TITLE
Expires getting null value when publishing 

### DIFF
--- a/src/Framework/N2/Edit/Workflow/Commands/EnsurePublishedCommand.cs
+++ b/src/Framework/N2/Edit/Workflow/Commands/EnsurePublishedCommand.cs
@@ -15,8 +15,12 @@ namespace N2.Edit.Workflow.Commands
                     state.Content.Published = Utility.CurrentTime();
             }
 
-			if (state.Content.Expires.HasValue)
-				state.Content.Expires = null;
+            if (Binding.GetUpdatedDetails(state).Contains("Expires"))
+                return;
+
+            if (state.Content.Expires.HasValue && state.Content.Expires.Value < Utility.CurrentTime())
+                state.Content.Expires = null;
+
         }
     }
 }

--- a/src/Framework/Tests/Workflow/CommandFactory_PublishingTests.cs
+++ b/src/Framework/Tests/Workflow/CommandFactory_PublishingTests.cs
@@ -85,6 +85,42 @@ namespace N2.Tests.Workflow
             Assert.That(item.Children[1], Is.EqualTo(child));
         }
 
+        [Test]
+        public void Expires_IsClearedIfExpiresHasPassed()
+        {
+            item.Expires = N2.Utility.CurrentTime().AddDays(-1);
+            var context = new CommandContext(definitions.GetDefinition(item.GetContentType()), item, Interfaces.Editing, CreatePrincipal("admin"), nullBinder, nullValidator);
+            var command = CreateCommand(context);
+            dispatcher.Execute(command, context);
+
+            Assert.That(context.Content.Expires, Is.Null);
+        }
+
+        [Test]
+        public void Expires_IsNotClearedIfExpiresInFuture()
+        {
+            var expireDate = N2.Utility.CurrentTime().AddDays(10);
+            item.Expires = expireDate;
+            var context = new CommandContext(definitions.GetDefinition(item.GetContentType()), item, Interfaces.Editing, CreatePrincipal("admin"), nullBinder, nullValidator);
+            var command = CreateCommand(context);
+            dispatcher.Execute(command, context);
+
+            Assert.That(context.Content.Expires, Is.EqualTo(expireDate));
+        }
+
+        [Test]
+        public void Expires_IsNotClearedIfExpiresHasPassedButIsEdited()
+        {
+            var expireDate = N2.Utility.CurrentTime().AddDays(-1);
+            item.Expires = expireDate;
+            var context = new CommandContext(definitions.GetDefinition(item.GetContentType()), item, Interfaces.Editing, CreatePrincipal("admin"), nullBinder, nullValidator);
+            context.Parameters.Add("UpdatedDetailsKey", new System.Collections.Generic.List<string> { "Expires" });
+            var command = CreateCommand(context);
+            dispatcher.Execute(command, context);
+
+            Assert.That(context.Content.Expires, Is.EqualTo(expireDate));
+        }
+
         //What's the point, really?
         //[Test]
         //public void Sets_PublishedDate()


### PR DESCRIPTION
Currently Expires will get null when publishing, even if Expires is set e.g via WithEditablePublishRangeAttribute.  
 
In order to set a future expire date, check if Expires has been changed or if Expires has a value in the future. If so, do not set Expires to null when publishing.