### PR TITLE
Removed unused PartsCount property.

### DIFF
--- a/src/Framework/N2/Edit/Api/ContentHandler.cs
+++ b/src/Framework/N2/Edit/Api/ContentHandler.cs
@@ -261,7 +261,7 @@ namespace N2.Management.Api
 			var requestBody = context.GetOrDeserializeRequestStreamJsonDictionary<object>();
 			var discriminator = EditExtensions.GetDiscriminator(context.Request);
 
-			var versions = engine.Resolve<VersionManager>();
+			var versions = engine.Resolve<IVersionManager>();
 			ContentItem item;
 			if (string.IsNullOrEmpty(discriminator))
 			{

--- a/src/Framework/N2/Edit/Versioning/VersionInfo.cs
+++ b/src/Framework/N2/Edit/Versioning/VersionInfo.cs
@@ -15,7 +15,6 @@ namespace N2.Edit.Versioning
         public virtual DateTime? FuturePublish { get; set; }
         public virtual DateTime? Expires { get; set; }
 		public virtual int VersionIndex { get; set; }
-		public virtual int PartsCount { get; set; }
         public virtual string SavedBy { get; set; }
 
         public virtual ContentItem Content { get { return ContentFactory(); } }

--- a/src/Framework/N2/Edit/Versioning/VersioningExtensions.cs
+++ b/src/Framework/N2/Edit/Versioning/VersioningExtensions.cs
@@ -206,8 +206,7 @@ namespace N2.Edit.Versioning
 				    SavedBy = version.SavedBy,
 				    State = version.State,
 				    Title = version.Title,
-				    VersionIndex = version.VersionIndex,
-				    PartsCount = version.ItemCount - 1
+				    VersionIndex = version.VersionIndex
 			    };
 		    }
 		    catch (Exception ex)
@@ -223,8 +222,7 @@ namespace N2.Edit.Versioning
 				    iv.State = version.State;
 				    iv.Title = version.Title;
 				    iv.VersionIndex = version.VersionIndex;
-				    iv.PartsCount = version.ItemCount - 1;
-
+				    
 				    if (version.Master.ID != null)
 					    iv.ID = version.Master.ID.Value;
 				    else
@@ -243,7 +241,6 @@ namespace N2.Edit.Versioning
 		    int pc = 0;
 		    try
 		    {
-			    pc = N2.Find.EnumerateChildren(version, includeSelf: false, useMasterVersion: false).Count();
 			    return new VersionInfo
 			    {
 				    ID = version.ID,
@@ -254,8 +251,7 @@ namespace N2.Edit.Versioning
 				    SavedBy = version.SavedBy,
 				    State = version.State,
 				    Title = version.Title,
-				    VersionIndex = version.VersionIndex,
-				    PartsCount = pc
+				    VersionIndex = version.VersionIndex
 			    };
 			}
 			catch (Exception ex)
@@ -271,7 +267,6 @@ namespace N2.Edit.Versioning
 					iv.State = version.State;
 					iv.Title = version.Title;
 					iv.VersionIndex = version.VersionIndex;
-					iv.PartsCount = pc;
 					iv.ID = version.ID;
 				}
 				else

--- a/src/Framework/Tests/Edit/ContentHandlerTests.cs
+++ b/src/Framework/Tests/Edit/ContentHandlerTests.cs
@@ -57,7 +57,7 @@ namespace N2.Tests.Edit
 			var activator = engine.Resolve<ContentActivator>();
 			var versionRepository = TestSupport.CreateVersionRepository(ref persister, ref activator, new Type[] { typeof(ContentHandlerTestsPage), typeof(ContentHandlerTestsPart) });
 			engine.AddComponentInstance<ContentVersionRepository>(versionRepository);
-			engine.AddComponentInstance<VersionManager>(versionManager = TestSupport.SetupVersionManager(engine.Persister, versionRepository));
+			engine.AddComponentInstance<IVersionManager>(versionManager = TestSupport.SetupVersionManager(engine.Persister, versionRepository));
 			(engine.Resolve<IContentAdapterProvider>() as N2.Plugin.IAutoStart).Start();
 			engine.Resolve<IContentAdapterProvider>().ResolveAdapter<N2.Edit.NodeAdapter>(typeof(ContentItem)).Engine = engine;
 			engine.AddComponentInstance(new HtmlSanitizer(new N2.Configuration.HostSection()));


### PR DESCRIPTION
1) Removed unused PartsCount property.
On every edit N2 creates VersionInfo for edited ContentItem before loading editor. On VersionInfo creation 
PartsCount property was filled using N2.Find.EnumerateChildren. EnumerateChildren recursively enumerates all subtree bellow edited ContentItem and causing multiple queries to database. If subtree is large enough this can significantly delay editor loading.

2) Fixed ContentHandler to create VersionManager using interface instead of class. This will allow to completely replace current VersionManager implementation.