### PR TITLE
Fixed version list after removing PartsCount property

### DIFF
--- a/src/Mvc/MvcTemplates/N2/Content/Versions/Default.aspx
+++ b/src/Mvc/MvcTemplates/N2/Content/Versions/Default.aspx
@@ -24,7 +24,6 @@
 			<asp:BoundField HeaderText="Published" DataField="Published" meta:resourceKey="published" />
 			<asp:BoundField HeaderText="Expired" DataField="Expires" meta:resourceKey="expires" />
 			<asp:BoundField HeaderText="Saved by" DataField="SavedBy" meta:resourceKey="savedBy" />
-			<asp:BoundField HeaderText="Parts count" DataField="PartsCount" meta:resourceKey="partsCount" />
 			<asp:TemplateField>
 				<ItemTemplate>
 					<asp:HyperLink runat="server" ID="hlEdit" meta:resourceKey="hlEdit" Text="Edit" NavigateUrl='<%# Engine.ManagementPaths.GetEditExistingItemUrl((N2.ContentItem)Eval("Content"), null, null) %>' />


### PR DESCRIPTION
PartsCount was used in the version list. If BoundField is not removed, full version list fails with RTE.
