### PR TITLE
Do not invoke ItemLoaded handler when item is null (upload folder with Id == "0")

### DIFF
--- a/src/Framework/N2/Persistence/NH/ContentPersister.cs
+++ b/src/Framework/N2/Persistence/NH/ContentPersister.cs
@@ -46,7 +46,8 @@ namespace N2.Persistence
         public virtual ContentItem Get(int id)
         {
             ContentItem item = sources.Get(id);
-            if (ItemLoaded != null)
+            // Upload folder 
+            if (item != null && ItemLoaded != null)
             {
                 return Invoke(ItemLoaded, new ItemEventArgs(item)).AffectedItem; 
             }


### PR DESCRIPTION
Description of a bug:
So since N2 upgrade to latest version (2.9.6.19) in our project, the upload folder got broken, i.e admins use to get exceptions when accessing it, trying to add or edit content
The reason is a bug in N2 latest version, ContentPersister.Get() method (line 51) where it assumes that item is not null. The only case (I know about) that the item can be null even after being fetched by Get(id) is when id == 0 - which means it's an upload folder. The upload folder seems to be a special kind of content in n2 tree - as the only one which is not persisted in the n2Item table. This is probably a reason why it has id==0.  Anyway, when the request is for upload folder, with an id of 0, the code doesn't check that the item can be null and runs ".AffectedItem" which causes NullReferenceException and entire request to fail.
So this is actually and N2 bug and the fix for it would be to check not only if itemLoaded is not null but also if item itself is not null.

Solution:
The trick in our projects to make the upload folder workable again was to not have any ItemLoaded eventhandler registered. However, the real fix should be to not invoke ItemLoaded handler in this special case, only for upload folder - where the item is null.