### PR TITLE
Do not read Type from empty meta attribute

### DIFF
--- a/src/Framework/N2/Persistence/Serialization/DetailCollectionXmlReader.cs
+++ b/src/Framework/N2/Persistence/Serialization/DetailCollectionXmlReader.cs
@@ -60,7 +60,7 @@ namespace N2.Persistence.Serialization
             }
             else if (type == typeof(Enum))
             {
-                if (meta != null)
+                if (!string.IsNullOrEmpty(meta))
                 {
                     collection.Add(ContentDetail.New(
                         collection.EnclosingItem,


### PR DESCRIPTION
It may occur that Enum types have empty meta attributes. This is probably a problem of a serializer which should not create such empty items, but instead not include them at all.
All in all, if empty meta item was read, the entire reader was failing and so did entire request processing resulted in 500 while reading a page.